### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -75,4 +75,4 @@ jobs:
         prerelease: false
     - name: Publish to PyPI
       run: |
-        python -m twine upload --verbose --non-interactive dist dist/*
+        python -m twine upload --verbose --non-interactive dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 47761
 
 WORKDIR /opt/tenzir/threatbus
 COPY setup.py .
+COPY README.md .
 COPY threatbus threatbus
 COPY plugins plugins
 RUN pip install . && \


### PR DESCRIPTION
- Remove unused keyword from `twine upload` step that made the build step fail.
- Copy readme in Docker container