### PR TITLE
Parse MISP events to update attributes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ plugins:
       #kafka:
       #  topics:
       #  - misp_attribute
+      #  - misp_event
       #  poll_interval: 1.0
       #  # All config entries are passed as-is to librdkafka
       #  # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md

--- a/plugins/apps/threatbus-misp/README.md
+++ b/plugins/apps/threatbus-misp/README.md
@@ -144,6 +144,8 @@ make deploy
   - `Plugin.Kafka_brokers` -> `172.17.0.1:9092`    <- In this example, 172.17.0.1 is the Docker host, reachable from other Docker networks. The port is reachable when the Kafka Docker setup binds to it globally.
   - `Plugin.Kafka_attribute_notifications_enable` -> `true`
   - `Plugin.Kafka_attribute_notifications_topic` -> `misp_attribute` <- The topic goes into the threatbus `config.yaml`
+  - `Plugin.Kafka_event_notifications_enable` -> `true`
+  - `Plugin.Kafka_event_notifications_topic` -> `misp_event` <- The topic goes into the threatbus `config.yaml`
 
 *Install Kafka inside the `misp-server` container*
 
@@ -173,6 +175,7 @@ exit # leave the Docker container shell
 - Find the ZeroMQ plugin section and enable it
 - Go to `Administration` -> `Server Settings & Maintenance` -> `Plugin settings Tab`
 - Set the entry `Plugin.ZeroMQ_attribute_notifications_enable` to `true`
+- Set the entry `Plugin.ZeroMQ_event_notifications_enable` to `true`
 
 *Restart all MISP services*
 


### PR DESCRIPTION
MISP is not forwarding attributes when events get deleted. There is currently no means to detect deleted events without carrying state.

This PR prepares the code for once the following issue is resolved: https://github.com/MISP/MISP/issues/4450