### PR TITLE
Add CI step to publish Docker image

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -29,6 +29,22 @@ jobs:
     - name: Package Application and Plugins
       run: |
         make clean dist
+  
+  publish-docker:
+    name: Publish to DockerHub
+    runs-on: ubuntu-latest
+    needs: egg-install
+    if: github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+    - name: Publish Docker Image 
+      uses: elgohr/Publish-Docker-Github-Action@2.12
+      with:
+        name: tenzir/threatbus
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   egg-release:
     name: Egg Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM fixel/zeek:broker-latest
 
-RUN apt-get update -qqy && apt-get install -qqy python3-pip
+RUN apt-get update -qqy && apt-get install -qqy \
+  python3-pip wget software-properties-common gnupg2
+RUN wget -qO - https://packages.confluent.io/deb/5.4/archive.key | apt-key add - && \
+  add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.4 stable main" && \
+  apt-get update -qqy && apt-get install -qqy confluent-platform-2.12
+
 RUN pip3 install --upgrade pip
 
 EXPOSE 47761
@@ -11,6 +16,7 @@ COPY README.md .
 COPY threatbus threatbus
 COPY plugins plugins
 RUN python3 setup.py install && \
+  python3 plugins/apps/threatbus_misp/setup.py install && \
   python3 plugins/apps/threatbus_zeek/setup.py install && \
   python3 plugins/backbones/threatbus_inmem/setup.py install
 COPY config* ./


### PR DESCRIPTION
CI step to build a `threatbus` image and push to the public `tenzir` DockerHub registry. 

See also [test run for the upload](https://github.com/tenzir/threatbus/runs/415470526?check_suite_focus=true#step:4:1) or try `docker run tenzir/threatbus:story-ch12293 -c config.yaml`.