### PR TITLE
Switch to Manual Release-Workflow with Calendar Versioning

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -1,5 +1,8 @@
 name: "Python Egg"
-on: push
+on:
+  push:
+  release:
+    types: published
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
@@ -30,11 +33,11 @@ jobs:
       run: |
         make clean dist
   
-  publish-docker:
+  docker-release:
     name: Publish to DockerHub
+    if: github.ref == 'refs/heads/master' || github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: egg-install
-    if: github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -48,12 +51,12 @@ jobs:
 
   egg-release:
     name: Egg Release
+    if: github.event.action == 'published'
     needs: egg-install
     runs-on: ubuntu-latest
     env:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -69,21 +72,23 @@ jobs:
     - name: Package Application and Plugins
       run: |
         make clean dist
-    - name: Create Release Name
-      id: release_name
+    - name: Create Release
+      id: create_release
       run: |
         NAME="Threat Bus $(date +%Y-%m-%d)"
+        ASSET="$NAME.tar.gz"
+        tar czf "$ASSET" dist
         echo "::set-output name=name::$NAME"
-    - name: GitHub Release
-      id: create_release
-      uses: actions/create-release@v1
+        echo "::set-output name=asset::$ASSET"
+    - name: Publish to GitHub
+      uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ steps.release_name.outputs.name }}
-        draft: false
-        prerelease: false
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ steps.create_release.outputs.asset}}
+        asset_name: ${{ steps.create_release.outputs.name}}
+        asset_content_type: application/gzip
     - name: Publish to PyPI
       run: |
         python -m twine upload --verbose --non-interactive dist/*

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with MISP.",
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
-        "threatbus>=0.3.2",
+        "threatbus>=2020.01.31",
         "pymisp>=2.4.120",
         "pyzmq>=18.1.1",
         "confluent-kafka>=1.3.0",
@@ -48,5 +48,5 @@ setup(
     packages=["threatbus_misp"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="0.3.2",
+    version="2020.01.31",
 )

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     description="A plugin to enable threatbus communication with Zeek network monitor.",
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
-    install_requires=["threatbus>=0.3.2",],
+    install_requires=["threatbus>=2020.01.31",],
     keywords=["threatbus", "Zeek", "intrusion detection", "IDS", "broker", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,
@@ -36,5 +36,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="0.3.2",
+    version="2020.01.31",
 )

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     description="A simplistic in-memory backbone for threatbus.",
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
-    install_requires=["threatbus>=0.3.2",],
+    install_requires=["threatbus>=2020.01.31",],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,
@@ -32,5 +32,5 @@ setup(
     packages=["threatbus_inmem"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="0.3.2",
+    version="2020.01.31",
 )

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="0.3.2",
+    version="2020.01.31",
 )


### PR DESCRIPTION
- After GitHub release has been written + published manually, the action will pick it up and publish artifacts to it
- PyPI versioning now uses CalVer schema