### PR TITLE
Add RabbitMQ Backbone Plugin

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -18,21 +18,44 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.ref }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up Dist Environment
       run: |
         python -m pip install --upgrade pip
-        pip install wheel setuptools
+        python -m pip install wheel setuptools
     - name: Install Application and Plugins
       run: |
         make clean build
     - name: Package Application and Plugins
       run: |
         make clean dist
-  
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    container: fixel/zeek:broker-latest
+      # The image is based on Debian-10 and has `zeek/broker` pre-installed
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.ref }}
+    - name: Set up Dist Environment
+      run: |
+        apt-get -qq update
+        apt-get -qqy install python3-pip 
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        python -m pip install --upgrade pip
+        python -m pip install wheel setuptools
+    - name: Install Application and Plugins
+      run: |
+        make dev-mode
+    - name: Run Unit Tests
+      run: |
+        make unit-tests
+
   docker-release:
     name: Publish to DockerHub
     if: github.ref == 'refs/heads/master' || github.event.action == 'published'
@@ -68,7 +91,7 @@ jobs:
     - name: Set up Dist Environment
       run: |
         python -m pip install --upgrade pip
-        pip install wheel setuptools twine
+        python -m pip install wheel setuptools twine
     - name: Package Application and Plugins
       run: |
         make clean dist

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv/
 **/*.egg-info/
 *tar.gz
 **/vast.db/
+config.yaml
+

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test: unit-tests integration-tests
 
 .PHONY: unit-tests
 unit-tests:
+	python -m unittest discover threatbus
 	python -m unittest discover plugins/apps
 	python -m unittest discover plugins/backbones
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+colon := :
+$(colon) := :
+
 .PHONY: all
 all: format build dist test
 
@@ -20,11 +23,15 @@ unit-tests:
 
 .PHONY: integration-tests
 integration-tests:
+	-docker kill tb-int rabbit-int
 	docker build . -t threatbus-integration-test
 	docker run -td --name=tb-int --rm -p 47761:47761 threatbus-integration-test -c config_integration_test.yaml
+	docker pull rabbitmq$(:)3
+	docker run -d --rm --hostname=test-rabbit --name=rabbit-int -p 35672$(:)5672 rabbitmq$(:)3
 	-python -m unittest tests/integration/test_zeek_inmem.py
+	-python -m unittest tests/integration/test_rabbitmq.py
 	-${RM} {broker,intel,reporter,weird}.log
-	docker kill tb-int
+	docker kill tb-int rabbit-int
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ build:
 	python plugins/apps/threatbus_vast/setup.py build
 	python plugins/apps/threatbus_cif3/setup.py build
 	python plugins/backbones/threatbus_inmem/setup.py build
+	python plugins/backbones/threatbus_rabbitmq/setup.py build
 
 .PHONY: dist
 dist:
@@ -53,6 +54,7 @@ dist:
 	python plugins/apps/threatbus_cif3/setup.py sdist bdist_wheel
 	make clean
 	python plugins/backbones/threatbus_inmem/setup.py sdist bdist_wheel
+	python plugins/backbones/threatbus_rabbitmq/setup.py sdist bdist_wheel
 	make clean
 
 .PHONY: install
@@ -63,6 +65,7 @@ install:
 	python plugins/apps/threatbus_vast/setup.py install
 	python plugins/apps/threatbus_cif3/setup.py install
 	python plugins/backbones/threatbus_inmem/setup.py install
+	python plugins/backbones/threatbus_rabbitmq/setup.py install
 
 .PHONY: dev-mode
 dev-mode:
@@ -72,3 +75,4 @@ dev-mode:
 	python plugins/apps/threatbus_vast/setup.py develop
 	python plugins/apps/threatbus_cif3/setup.py develop
 	python plugins/backbones/threatbus_inmem/setup.py develop
+	python plugins/backbones/threatbus_rabbitmq/setup.py develop

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,14 @@ unit-tests:
 
 .PHONY: integration-tests
 integration-tests:
-	-docker kill tb-int rabbit-int
-	docker build . -t threatbus-integration-test
-	docker run -td --name=tb-int --rm -p 47761:47761 threatbus-integration-test -c config_integration_test.yaml
+	-docker kill rabbit-int
 	docker pull rabbitmq$(:)3
 	docker run -d --rm --hostname=test-rabbit --name=rabbit-int -p 35672$(:)5672 rabbitmq$(:)3
-	-python -m unittest tests/integration/test_zeek_inmem.py
+	-python -m unittest tests/integration/test_message_roundtrips.py
+	-python -m unittest tests/integration/test_zeek_app.py
 	-python -m unittest tests/integration/test_rabbitmq.py
 	-${RM} {broker,intel,reporter,weird}.log
-	docker kill tb-int rabbit-int
+	docker kill rabbit-int
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Chat with us on [Matrix][chat-url].
 
 ## Getting Started
 
+The `config.yaml.example` file provides a working configuration for Threat Bus
+with all existing application plugins enabled together with the RabbitMQ
+backbone.
+
 The following example shows how to connect [MISP][misp], [Zeek][zeek] via
 Threat Bus. There are more integrations available, so make sure to check out all
 [Threat Bus projects on PyPI](https://pypi.org/search/?q=threatbus).
@@ -49,6 +53,7 @@ Threat Bus. There are more integrations available, so make sure to check out all
 *Start Threat Bus*
 
 ```sh
+mv config.yaml.example config.yaml   # rename example config file
 venv/bin/threatbus -c config.yaml
 ```
 
@@ -91,6 +96,7 @@ pip install threatbus
 pip install threatbus-inmem
 pip install threatbus-misp
 pip install threatbus-zeek
+pip install threatbus-rabbitmq
 pip install threatbus-<plugin_name>
 ```
 

--- a/apps/vast/requirements.txt
+++ b/apps/vast/requirements.txt
@@ -1,3 +1,3 @@
 coloredlogs>=14.0
 pyzmq>=19
-pyvast>=2020.5.29
+pyvast>=2020.8.28

--- a/apps/vast/vast-bridge.py
+++ b/apps/vast/vast-bridge.py
@@ -400,6 +400,7 @@ def main():
         "-s",
         dest="snapshot",
         default=0,
+        type=int,
         help="Request intelligence snapshot for past n days",
     )
     parser.add_argument(

--- a/apps/vast/vast-bridge.py
+++ b/apps/vast/vast-bridge.py
@@ -10,7 +10,6 @@ import logging
 from pyvast import VAST
 import random
 from string import ascii_lowercase as letters
-import sys
 import zmq
 
 logger = logging.getLogger(__name__)
@@ -68,7 +67,7 @@ async def start(
     if not pub_endpoint or not sub_endpoint or not topic:
         logger.error("Unparsable subscription reply")
         exit(1)
-    logger.debug(f"Subscription successfull")
+    logger.debug("Subscription successfull")
     atexit.register(unsubscribe, zmq_endpoint, topic)
 
     intel_queue = asyncio.Queue()

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,11 @@ logging:
 
 plugins:
   backbones:
-    inmem:
+    #inmem:
+    rabbitmq:
+      host: localhost
+      port: 5672
+
   apps:
     zeek:
       host: "127.0.0.1"
@@ -37,14 +41,14 @@ plugins:
         manage: 13370
         pub: 13371
         sub: 13372
-    cif3:
-      api:
-        host: http://localhost:5000
-        ssl: false
-        token: CIF_TOKEN
-      group: everyone
-      confidence: 7.5
-      tlp: amber
-      tags:
-        - test
-        - malicious
+    #cif3:
+    #  api:
+    #    host: http://localhost:5000
+    #    ssl: false
+    #    token: CIF_TOKEN
+    #  group: everyone
+    #  confidence: 7.5
+    #  tlp: amber
+    #  tags:
+    #    - test
+    #    - malicious

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,6 +10,17 @@ plugins:
     rabbitmq:
       host: localhost
       port: 5672
+      username: guest
+      password: guest
+      vhost: /
+      naming_join_pattern: . # symbol to concatenate names with. Example queue-name: threatbus.intel."hostname"
+      queue:
+        name_suffix: "my_suffix" # optional. remove property / set empty to use 'hostname'
+        durable: true
+        auto_delete: false
+        lazy: true
+        exclusive: false
+        max_items: 100000 # optional. remove property / set to 0 to allow infinite length
 
   apps:
     zeek:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -7,7 +7,6 @@ logging:
 
 plugins:
   backbones:
-    #inmem:
     rabbitmq:
       host: localhost
       port: 5672
@@ -41,14 +40,14 @@ plugins:
         manage: 13370
         pub: 13371
         sub: 13372
-    #cif3:
-    #  api:
-    #    host: http://localhost:5000
-    #    ssl: false
-    #    token: CIF_TOKEN
-    #  group: everyone
-    #  confidence: 7.5
-    #  tlp: amber
-    #  tags:
-    #    - test
-    #    - malicious
+    cif3:
+      api:
+        host: http://localhost:5000
+        ssl: false
+        token: CIF_TOKEN
+      group: everyone
+      confidence: 7.5
+      tlp: amber
+      tags:
+        - test
+        - malicious

--- a/config_integration_test.yaml
+++ b/config_integration_test.yaml
@@ -1,10 +1,6 @@
 logging:
-  console: true
-  console_verbosity: DEBUG
+  console: false
   file: false
-  file_verbosity: DEBUG
-  filename: threatbus.log
-
 
 plugins:
   backbones:

--- a/plugins/apps/threatbus_cif3/plugin.py
+++ b/plugins/apps/threatbus_cif3/plugin.py
@@ -77,7 +77,7 @@ def run(config, logging, inq, subscribe_callback, unsubscribe_callback):
         cif.ping()
     except Exception as err:
         logger.error(
-            f"Cannot connect to CIFv3 at {remote}, using SSL: {ssl}. Exiting plugin."
+            f"Cannot connect to CIFv3 at {remote}, using SSL: {ssl}. Exiting plugin. {err}"
         )
         return
 

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     description="A plugin to enable indicators to be submitted to CIFv3 in real-time",
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
-    install_requires=["cifsdk>3.0.0rc4,<4.0"],
+    install_requires=["threatbus>=2020.09.30", "cifsdk>3.0.0rc4,<4.0"],
     keywords=[
         "cif",
         "cifv3",
@@ -47,5 +47,5 @@ setup(
     packages=["threatbus_cif3"],
     python_requires=">=3.6",
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/plugins/apps/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/plugin.py
@@ -131,7 +131,7 @@ def receive_zmq(zmq_config, inq):
 def snapshot(snapshot_type, result_q, time_delta):
     global logger, misp, lock
     if snapshot_type != MessageType.INTEL:
-        logger.debug(f"Sighting snapshot feature not yet implemented.")
+        logger.debug("Sighting snapshot feature not yet implemented.")
         return  # TODO sighting snapshot not yet implemented
 
     if not misp:

--- a/plugins/apps/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/plugin.py
@@ -101,6 +101,7 @@ def receive_zmq(zmq_config, inq):
     @param zmq_config A configuration object for ZeroMQ binding
     @param inq The queue to which intel items from MISP are forwarded to
     """
+    global logger
     socket = zmq.Context().socket(zmq.SUB)
     socket.connect(f"tcp://{zmq_config['host']}:{zmq_config['port']}")
     # TODO: allow reception of more topics, i.e. handle events.

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with MISP.",
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
-        "threatbus>=2020.04.29",
+        "threatbus>=2020.09.30",
         "pymisp>=2.4.120",
         "pyzmq>=18.1.1",
         "confluent-kafka>=1.3.0",
@@ -48,5 +48,5 @@ setup(
     packages=["threatbus_misp"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/plugins/apps/threatbus_vast/plugin.py
+++ b/plugins/apps/threatbus_vast/plugin.py
@@ -156,4 +156,4 @@ def run(config, logging, inq, subscribe_callback, unsubscribe_callback):
         args=(config["zmq"], subscribe_callback, unsubscribe_callback),
         daemon=True,
     ).start()
-    logger.info(f"VAST plugin started")
+    logger.info("VAST plugin started")

--- a/plugins/apps/threatbus_vast/setup.py
+++ b/plugins/apps/threatbus_vast/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with VAST.",
     entry_points={"threatbus.app": ["vast = threatbus_vast.plugin"]},
     install_requires=[
-        "threatbus>=2020.04.29",
+        "threatbus>=2020.09.30",
         "pyzmq>=19",
         "pyvast>=2020.08.28",
         "python-dateutil>=2.8.1",
@@ -45,5 +45,5 @@ setup(
     packages=["threatbus_vast"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/plugins/apps/threatbus_vast/setup.py
+++ b/plugins/apps/threatbus_vast/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "threatbus>=2020.04.29",
         "pyzmq>=19",
-        "pyvast>=2020.03.26",
+        "pyvast>=2020.08.28",
         "python-dateutil>=2.8.1",
     ],
     keywords=[

--- a/plugins/apps/threatbus_zeek/plugin.py
+++ b/plugins/apps/threatbus_zeek/plugin.py
@@ -1,5 +1,4 @@
 import broker
-from copy import copy
 from queue import Queue
 import random
 import select

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with Zeek network monitor.",
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
     install_requires=[
-        "threatbus>=2020.04.29",
+        "threatbus>=2020.09.30",
     ],
     keywords=["threatbus", "Zeek", "intrusion detection", "IDS", "broker", "plugin"],
     license="BSD 3-clause",
@@ -38,5 +38,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/plugins/backbones/threatbus_inmem/plugin.py
+++ b/plugins/backbones/threatbus_inmem/plugin.py
@@ -14,12 +14,12 @@ def validate_config(config):
     return True
 
 
-def provision(logger, inq):
-    """Provisions all messages that arrive on the inq to all subscribers of that topic.
-    @param logger A logging.logger object
+def provision(inq):
+    """
+    Provisions all messages that arrive on the inq to all subscribers of that topic.
     @param inq The in-Queue to read messages from
     """
-    global subscriptions, lock
+    global subscriptions, lock, logger
     while True:
         msg = inq.get(block=True)
         logger.debug(f"Backbone got message {msg}")
@@ -64,5 +64,5 @@ def run(config, logging, inq):
         validate_config(config)
     except Exception as e:
         logger.fatal("Invalid config for plugin {}: {}".format(plugin_name, str(e)))
-    threading.Thread(target=provision, args=(logger, inq), daemon=True).start()
+    threading.Thread(target=provision, args=(inq,), daemon=True).start()
     logger.info("In-memory backbone started.")

--- a/plugins/backbones/threatbus_inmem/plugin.py
+++ b/plugins/backbones/threatbus_inmem/plugin.py
@@ -32,13 +32,6 @@ def provision(inq):
 
 
 @threatbus.backbone
-def provision_p2p(src_q, dst_q):
-    while not src_q.empty():
-        msg = src_q.get(timeout=5)
-        dst_q.put(msg)
-
-
-@threatbus.backbone
 def subscribe(topic, q):
     global subscriptions, lock
     lock.acquire()

--- a/plugins/backbones/threatbus_inmem/plugin.py
+++ b/plugins/backbones/threatbus_inmem/plugin.py
@@ -29,6 +29,7 @@ def provision(inq):
             for outq in subscriptions[t]:
                 outq.put(msg)
         lock.release()
+        inq.task_done()
 
 
 @threatbus.backbone

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -22,9 +22,7 @@ setup(
     ],
     description="A simplistic in-memory backbone for threatbus.",
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
-    install_requires=[
-        "threatbus>=2020.04.29",
-    ],
+    install_requires=["threatbus>=2020.09.30"],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,
@@ -34,5 +32,5 @@ setup(
     packages=["threatbus_inmem"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/plugins/backbones/threatbus_rabbitmq/README.md
+++ b/plugins/backbones/threatbus_rabbitmq/README.md
@@ -1,0 +1,2 @@
+Threat Bus Rabbit MQ Backbone
+=============================

--- a/plugins/backbones/threatbus_rabbitmq/README.md
+++ b/plugins/backbones/threatbus_rabbitmq/README.md
@@ -1,2 +1,44 @@
-Threat Bus Rabbit MQ Backbone
-=============================
+Threat Bus RabbitMQ Backbone Plugin
+===================================
+
+<h4 align="center">
+
+[![PyPI Status][pypi-badge]][pypi-url]
+[![Build Status][ci-badge]][ci-url]
+[![License][license-badge]][license-url]
+
+</h4>
+
+A Threat Bus plugin to use RabbitMQ as message broker backbone.
+
+## Installation
+
+```sh
+pip install threatbus-rabbitmq
+```
+
+## Configuration
+
+The plugin requires a RabbitMQ endpoint to start.
+
+```yaml
+...
+plugins:
+  backbones:
+    rabbitmq:
+      host: localhost
+      port: 5672
+...
+```
+
+
+## License
+
+Threat Bus comes with a [3-clause BSD license][license-url].
+
+[pypi-badge]: https://img.shields.io/pypi/v/threatbus-rabbitmq.svg
+[pypi-url]: https://pypi.org/project/threatbus-rabbitmq
+[ci-url]: https://github.com/tenzir/threatbus/actions?query=branch%3Amaster
+[ci-badge]: https://github.com/tenzir/threatbus/workflows/Python%20Egg/badge.svg?branch=master
+[license-badge]: https://img.shields.io/badge/license-BSD-blue.svg
+[license-url]: https://github.com/tenzir/threatbus/blob/master/COPYING

--- a/plugins/backbones/threatbus_rabbitmq/plugin.py
+++ b/plugins/backbones/threatbus_rabbitmq/plugin.py
@@ -1,0 +1,50 @@
+import threading
+from collections import defaultdict
+import threatbus
+
+"""RabbitMQ backbone plugin for Threat Bus"""
+
+plugin_name = "rabbitmq"
+
+subscriptions = defaultdict(set)
+lock = threading.Lock()
+
+
+def validate_config(config):
+    return True
+
+
+def provision(inq):
+    """
+    Provisions all messages that arrive on the inq to all subscribers of that topic.
+    @param inq The in-Queue to read messages from
+    """
+    pass
+
+
+@threatbus.backbone
+def provision_p2p(src_q, dst_q):
+    pass
+
+
+@threatbus.backbone
+def subscribe(topic, q):
+    pass
+
+
+@threatbus.backbone
+def unsubscribe(topic, q):
+    pass
+
+
+@threatbus.backbone
+def run(config, logging, inq):
+    global logger
+    logger = threatbus.logger.setup(logging, __name__)
+    config = config[plugin_name]
+    try:
+        validate_config(config)
+    except Exception as e:
+        logger.fatal("Invalid config for plugin {}: {}".format(plugin_name, str(e)))
+    threading.Thread(target=provision, args=(inq,), daemon=True).start()
+    logger.info("RabbitMQ backbone started.")

--- a/plugins/backbones/threatbus_rabbitmq/plugin.py
+++ b/plugins/backbones/threatbus_rabbitmq/plugin.py
@@ -165,12 +165,6 @@ def publish_rabbitmq(host, port, inq):
 
 
 @threatbus.backbone
-def provision_p2p(src_q, dst_q):
-    # TODO
-    pass
-
-
-@threatbus.backbone
 def subscribe(topic, q):
     global subscriptions, lock
     lock.acquire()

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     description="A RabbitMQ backbone for threatbus.",
     entry_points={"threatbus.backbone": ["rabbitmq = threatbus_rabbitmq.plugin"]},
-    install_requires=["threatbus>=2020.07.28", "pika>=1.1.0", "retry"],
+    install_requires=["threatbus>=2020.09.30", "pika>=1.1.0", "retry"],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     description="A RabbitMQ backbone for threatbus.",
     entry_points={"threatbus.backbone": ["rabbitmq = threatbus_rabbitmq.plugin"]},
-    install_requires=["threatbus>=2020.07.28", "pika>=1.1.0"],
+    install_requires=["threatbus>=2020.07.28", "pika>=1.1.0", "retry"],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -1,0 +1,36 @@
+from setuptools import setup
+import pathlib
+
+plugin_dir = pathlib.Path(__file__).parent.absolute()
+
+with open(f"{plugin_dir}/README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    author="Tenzir",
+    author_email="engineering@tenzir.com",
+    classifiers=[
+        # https://pypi.org/classifiers/
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+        "Topic :: Security",
+        "Topic :: Software Development :: Object Brokering",
+    ],
+    description="A RabbitMQ backbone for threatbus.",
+    entry_points={"threatbus.backbone": ["rabbitmq = threatbus_rabbitmq.plugin"]},
+    install_requires=["threatbus>=2020.07.28", "pika>=1.1.0"],
+    keywords=["threatbus", "plugin"],
+    license="BSD 3-clause",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    name="threatbus-rabbitmq",
+    package_dir={"": "plugins/backbones"},
+    packages=["threatbus_rabbitmq"],
+    python_requires=">=3.8",
+    url="https://github.com/tenzir/threatbus",
+    version="2020.09.30",
+)

--- a/plugins/backbones/threatbus_rabbitmq/test_plugin.py
+++ b/plugins/backbones/threatbus_rabbitmq/test_plugin.py
@@ -1,0 +1,30 @@
+import unittest
+
+from threatbus_rabbitmq.plugin import (
+    get_exchange_name,
+    get_queue_name,
+)
+
+
+class TestNameCreation(unittest.TestCase):
+    def setUp(self):
+        self.queue_name_suffix = "SUFFIX"
+        self.join_pattern = "."
+
+    def test_exchange_name_creation(self):
+        data_type = "DATA_TYPE"
+        self.assertEqual(
+            get_exchange_name(self.join_pattern, data_type),
+            "threatbus" + self.join_pattern + data_type,
+        )
+
+    def test_queue_name_creation(self):
+        data_type = "DATA_TYPE"
+        self.assertEqual(
+            get_queue_name(self.join_pattern, data_type, self.queue_name_suffix),
+            "threatbus"
+            + self.join_pattern
+            + data_type
+            + self.join_pattern
+            + self.queue_name_suffix,
+        )

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2020.07.28",
+    version="2020.09.30",
 )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "confuse>=1.0",
         "pluggy>=0.13",
         "black>=19.10b",
+        "python-dateutil>=2.8.1",
     ],
     keywords=[
         "threatbus",

--- a/tests/integration/test_message_roundtrips.py
+++ b/tests/integration/test_message_roundtrips.py
@@ -1,0 +1,43 @@
+import confuse
+import queue
+import threading
+from threatbus import start
+import time
+import unittest
+
+from tests.utils import zeek_receiver, zeek_sender
+
+
+class TestMessageRoundtrip(unittest.TestCase):
+    def setUp(self):
+        config = confuse.Configuration("threatbus")
+        config.set_file("config_integration_test.yaml")
+        self.threatbus = threading.Thread(
+            target=start,
+            args=(config,),
+            daemon=True,
+        )
+        self.threatbus.start()
+        time.sleep(1)
+
+    def test_zeek_plugin_message_roundtrip(self):
+        """
+        Backend agnostic message passing screnario. Sends a fixed amount of
+        messages via the threatbus Zeek plugin, subscribes to Threat Bus, and
+        checks if the initially sent messages can be retrieved back.
+        """
+        result_q = queue.Queue()
+        items = 5
+        rec = threading.Thread(
+            target=zeek_receiver.forward, args=(items, result_q), daemon=False
+        )
+        rec.start()
+        zeek_sender.send_generic("threatbus/intel", items)
+        time.sleep(1)
+        self.assertEqual(result_q.qsize(), items)
+        for _ in range(items):
+            event = result_q.get(timeout=1)
+            self.assertIsNotNone(event)
+            result_q.task_done()
+        self.assertEqual(0, result_q.qsize())
+        result_q.join()

--- a/tests/integration/test_message_roundtrips.py
+++ b/tests/integration/test_message_roundtrips.py
@@ -22,7 +22,7 @@ class TestMessageRoundtrip(unittest.TestCase):
 
     def test_zeek_plugin_message_roundtrip(self):
         """
-        Backend agnostic message passing screnario. Sends a fixed amount of
+        Backend-agnostic message passing scenario. Sends a fixed amount of
         messages via the threatbus Zeek plugin, subscribes to Threat Bus, and
         checks if the initially sent messages can be retrieved back.
         """

--- a/tests/integration/test_rabbitmq.py
+++ b/tests/integration/test_rabbitmq.py
@@ -79,6 +79,16 @@ class TestRoundtrips(unittest.TestCase):
         config["rabbitmq"].add({})
         config["rabbitmq"]["host"] = "localhost"
         config["rabbitmq"]["port"] = 35672
+        config["rabbitmq"]["username"] = "guest"
+        config["rabbitmq"]["password"] = "guest"
+        config["rabbitmq"]["vhost"] = "/"
+        config["rabbitmq"]["naming_join_pattern"] = "."
+        config["rabbitmq"]["queue"].add({})
+        config["rabbitmq"]["queue"]["durable"] = False
+        config["rabbitmq"]["queue"]["auto_delete"] = True
+        config["rabbitmq"]["queue"]["exclusive"] = False
+        config["rabbitmq"]["queue"]["lazy"] = False
+        config["rabbitmq"]["queue"]["max_items"] = 10
         config["console"] = False
         config["file"] = False
 

--- a/tests/integration/test_rabbitmq.py
+++ b/tests/integration/test_rabbitmq.py
@@ -12,6 +12,7 @@ from threatbus.data import (
     SnapshotEnvelope,
     SnapshotRequest,
 )
+import time
 import unittest
 
 
@@ -90,6 +91,7 @@ class TestRoundtrips(unittest.TestCase):
         plugin.subscribe("threatbus/sighting", self.outq)
         plugin.subscribe("threatbus/snapshotrequest", self.outq)
         plugin.subscribe("threatbus/snapshotenvelope", self.outq)
+        time.sleep(1)
 
     def test_intel_message_roundtrip(self):
         """

--- a/tests/integration/test_rabbitmq.py
+++ b/tests/integration/test_rabbitmq.py
@@ -1,0 +1,128 @@
+import confuse
+from datetime import datetime, timedelta
+from plugins.backbones.threatbus_rabbitmq import plugin
+from queue import Queue
+from threatbus.data import (
+    Intel,
+    IntelData,
+    IntelType,
+    MessageType,
+    Operation,
+    Sighting,
+    SnapshotEnvelope,
+    SnapshotRequest,
+)
+import unittest
+
+
+class TestRoundtrips(unittest.TestCase):
+    def setUp(self):
+        self.ts = datetime.now().astimezone()
+        self.intel_id = "intel-42"
+        self.indicator = "6.6.6.6"
+        self.intel_type = IntelType.IPSRC
+        self.operation = Operation.ADD
+        self.intel_data = IntelData(
+            self.indicator, self.intel_type, foo=23, more_args="MORE ARGS"
+        )
+        self.intel = Intel(self.ts, self.intel_id, self.intel_data, self.operation)
+
+        self.sighting_context = {
+            "ts": "2017-03-03T23:56:09.652643840",
+            "uid": "CMeLkt11aTqwgN4FI9",
+            "id.orig_h": "172.31.130.19",
+            "id.orig_p": 43872,
+            "id.resp_h": "172.31.129.17",
+            "id.resp_p": 20004,
+            "proto": "tcp",
+            "service": None,
+            "duration": 0.025249,
+            "orig_bytes": 311,
+            "resp_bytes": 999,
+            "conn_state": "SF",
+            "local_orig": None,
+            "local_resp": None,
+            "missed_bytes": 0,
+            "history": "ShADadFf",
+            "orig_pkts": 9,
+            "orig_ip_bytes": 787,
+            "resp_pkts": 7,
+            "resp_ip_bytes": 1371,
+            "tunnel_parents": [],
+            "alert": {
+                "signature": "VAST-RETRO Generic IoC match for: 172.31.129.17",
+                "category": "Potentially Bad Traffic",
+                "action": "allowed",
+            },
+            "event_type": "alert",
+            "_extra": {"vast-ioc": "172.31.129.17"},
+            "source": "VAST",
+        }
+        self.sighting = Sighting(self.ts, self.intel_id, self.sighting_context)
+
+        self.snapshot_id = "SNAPSHOT_UUID"
+        self.snapshot = timedelta(days=42, hours=23, minutes=13, seconds=37)
+        self.snapshot_request = SnapshotRequest(
+            MessageType.SIGHTING, self.snapshot_id, self.snapshot
+        )
+
+        self.snapshot_envelope_intel = SnapshotEnvelope(
+            MessageType.INTEL, self.snapshot_id, self.intel
+        )
+        self.snapshot_envelope_sighting = SnapshotEnvelope(
+            MessageType.SIGHTING, self.snapshot_id, self.sighting
+        )
+
+        # setup the backbone with a fan-in queue
+        config = confuse.Configuration("threatbus")
+        config["rabbitmq"].add({})
+        config["rabbitmq"]["host"] = "localhost"
+        config["rabbitmq"]["port"] = 35672
+        config["console"] = False
+        config["file"] = False
+
+        self.inq = Queue()
+        plugin.run(config, config, self.inq)
+
+        # subscribe this test case as concumer
+        self.outq = Queue()
+        plugin.subscribe("threatbus/intel", self.outq)
+        plugin.subscribe("threatbus/sighting", self.outq)
+        plugin.subscribe("threatbus/snapshotrequest", self.outq)
+        plugin.subscribe("threatbus/snapshotenvelope", self.outq)
+
+    def test_intel_message_roundtrip(self):
+        """
+        Passes an Intel item to RabbitMQ and reads back the exact same item.
+        """
+        self.inq.put(self.intel)
+        out = self.outq.get(timeout=10)  # raise after 10s without item
+        self.assertEqual(self.intel, out)
+
+    def test_sighting_message_roundtrip(self):
+        """
+        Passes an Sighting item to RabbitMQ and reads back the exact same item.
+        """
+        self.inq.put(self.sighting)
+        out = self.outq.get(timeout=10)  # raise after 10s without item
+        self.assertEqual(self.sighting, out)
+
+    def test_snapshot_request_message_roundtrip(self):
+        """
+        Passes an SnapshotRequest item to RabbitMQ and reads back the exact same item.
+        """
+        self.inq.put(self.snapshot_request)
+        out = self.outq.get(timeout=10)  # raise after 10s without item
+        self.assertEqual(self.snapshot_request, out)
+
+    def test_snapshot_envelope_message_roundtrip(self):
+        """
+        Passes an SnapshotEnvelope item to RabbitMQ and reads back the exact same item.
+        """
+        self.inq.put(self.snapshot_envelope_intel)
+        out = self.outq.get(timeout=10)  # raise after 10s without item
+        self.assertEqual(self.snapshot_envelope_intel, out)
+
+        self.inq.put(self.snapshot_envelope_sighting)
+        out = self.outq.get(timeout=10)  # raise after 10s without item
+        self.assertEqual(self.snapshot_envelope_sighting, out)

--- a/tests/integration/test_zeek_app.py
+++ b/tests/integration/test_zeek_app.py
@@ -73,7 +73,7 @@ class TestZeekSightingReports(unittest.TestCase):
 
     def test_intel_sighting_roundtrip(self):
         """
-        Backend agnostic routrip screnario, that starts a Zeek
+        Backend-agnostic roundtrip scenario, that starts a Zeek
         subprocess. Zeek is started using the threatbus.zeek "app" script.
         The test sends an intelligence item via Threat Bus. The Zeek
         subprocess reads a PCAP trace which contains that known threat

--- a/tests/utils/zeek_receiver.py
+++ b/tests/utils/zeek_receiver.py
@@ -3,16 +3,18 @@
 import broker
 from datetime import timedelta
 import select
-import sys
 
 
-def receive(items, topic="threatbus/intel"):
+def receive(items, topic="threatbus/intel", td=timedelta(days=0)):
     ep = broker.Endpoint()
     ep.peer("127.0.0.1", 47761)
-    td = timedelta(days=0)
     subscribe_event = broker.zeek.Event("Tenzir::subscribe", topic, td)
     ep.publish("threatbus/manage", subscribe_event)
     manage = ep.make_subscriber("threatbus/manage")
+    fd_sets = select.select([manage.fd()], [], [])
+    if not fd_sets[0]:
+        print("Peering with remote machine failed.")
+        return
     _, data = manage.get()
     topic = broker.zeek.Event(data).args()[0]
     subscriber = ep.make_subscriber(topic)
@@ -20,14 +22,18 @@ def receive(items, topic="threatbus/intel"):
     for _ in range(items):
         fd_sets = select.select([subscriber.fd()], [], [])
         if not fd_sets[0]:
-            print("boom. this is the end.")
-            sys.exit(1)
+            print("Receiving data from Threat Bus failed.")
+            return
         _, data = subscriber.get()
         yield broker.zeek.Event(data)
+    unsubscribe_event = broker.zeek.Event("Tenzir::unsubscribe", topic)
+    ep.publish("threatbus/manage", unsubscribe_event)
 
 
 def forward(items, q, topic="threatbus/intel"):
-    """Receives the requested amount of items and forwards them to a queue.Queue"""
+    """
+    Receives the requested amount of items and forwards them to a queue.Queue
+    """
     for item in receive(items, topic):
         q.put(item)
 

--- a/threatbus/__init__.py
+++ b/threatbus/__init__.py
@@ -1,4 +1,5 @@
 import pluggy
+from .threatbus import ThreatBus, start
 
 app = pluggy.HookimplMarker("threatbus.app")
 """Marker to be imported and used in app-plugins"""

--- a/threatbus/appspecs.py
+++ b/threatbus/appspecs.py
@@ -5,7 +5,8 @@ hookspec = pluggy.HookspecMarker("threatbus.app")
 
 @hookspec
 def run(config, logging, inq, subscribe_callback, unsubscribe_callback):
-    """Runs / starts a plugin spec with a configuration object
+    """
+    Runs / starts a plugin spec with a configuration object
     @param config A configuration object for the app
     @param logging A configuration object for the logger
     @param inq A queue in which this plugin puts incoming messages
@@ -17,10 +18,11 @@ def run(config, logging, inq, subscribe_callback, unsubscribe_callback):
 
 
 @hookspec
-def snapshot(snapshot_type, result_q, time_delta):
-    """Requests a snapshot from the implementing plugin. Snapshot are returned
-    up to the requested earliest date. Results are put to the result_q.
-    @param snapshot_type @see threatbus.data.MessageType
+def snapshot(snapshot_request, result_q):
+    """
+    Perform a snapshot, based on the given `snapshot_request`. Snapshots are
+    collected up to the requested earliest date. Results of the type
+    threatbus.data.SnapshotEnvelope are put to the result_q.
+    @param snapshot_request @see threatbus.data.SnapshotRequest
     @param result_q Snapshot results are forwarded to this queue
-    @param time_delta A datetime.timedelta object to mark the snapshot size
     """

--- a/threatbus/backbonespecs.py
+++ b/threatbus/backbonespecs.py
@@ -26,11 +26,3 @@ def unsubscribe(topic, q):
     @param topic Unsubscribe from this topic (string)
     @param q The queue object that was subscribed to the given topic
     """
-
-
-@hookspec
-def provision_p2p(src_q, dst_q):
-    """Provisions all messages from src_q to dst_q
-    @param src_q The queue to read messages from
-    @param dst_q The queue to write messages to
-    """

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -119,6 +119,12 @@ class Sighting:
 
 @dataclass()
 class SnapshotEnvelope:
+    """
+    SnapshotEnvelopes are used to wrap intel items or sightings in response to
+    SnapshotRequests. The envelope carries additional information, such as the
+    MessageType and the unique ID of a snapshot.
+    """
+
     snapshot_type: MessageType
     snapshot_id: str
     body: Intel or Sighting
@@ -126,6 +132,13 @@ class SnapshotEnvelope:
 
 @dataclass
 class SnapshotRequest:
+    """
+    Threat Bus creates SnapshotRequests when apps specifically as for a snapshot
+    during subscription. SnapshotRequests are provisioned via the backbones.
+    A request consists of the requested MessageType (either INTEL or SIGHTING),
+    a unique ID, and the snapshot time delta (e.g., 30 days).
+    """
+
     snapshot_type: MessageType
     snapshot_id: str
     snapshot: timedelta

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -157,9 +157,9 @@ class IntelDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.decode_hook, *args, **kwargs)
 
-    def object_hook(self, dct: dict):
+    def decode_hook(self, dct: dict):
         if "intel_type" in dct and "indicator" in dct:
             # parse IntelData
             intel_type = IntelType(int(dct.pop("intel_type")))
@@ -198,9 +198,9 @@ class SightingDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.decode_hook, *args, **kwargs)
 
-    def object_hook(self, dct: dict):
+    def decode_hook(self, dct: dict):
         if "ts" in dct and "intel" in dct and "context" in dct:
             return Sighting(parser.parse(dct["ts"]), dct["intel"], dct["context"])
         return dct
@@ -228,9 +228,9 @@ class SnapshotRequestDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.decode_hook, *args, **kwargs)
 
-    def object_hook(self, dct: dict):
+    def decode_hook(self, dct: dict):
         if "snapshot_type" in dct and "snapshot_id" in dct and "snapshot" in dct:
             return SnapshotRequest(
                 MessageType(int(dct["snapshot_type"])),
@@ -270,9 +270,9 @@ class SnapshotEnvelopeDecoder(json.JSONDecoder):
     """
 
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.decode_hook, *args, **kwargs)
 
-    def object_hook(self, dct: dict):
+    def decode_hook(self, dct: dict):
         if "snapshot_type" in dct and "snapshot_id" in dct and "body" in dct:
             snapshot_type = MessageType(int(dct["snapshot_type"]))
             return SnapshotEnvelope(
@@ -288,7 +288,7 @@ class SnapshotEnvelopeDecoder(json.JSONDecoder):
             and "data" in dct
             and "operation" in dct
         ):
-            return IntelDecoder.object_hook(self, dct)
+            return IntelDecoder.decode_hook(self, dct)
         elif "ts" in dct and "intel" in dct and "context" in dct:
-            return SightingDecoder.object_hook(self, dct)
+            return SightingDecoder.decode_hook(self, dct)
         return dct

--- a/threatbus/test_data.py
+++ b/threatbus/test_data.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+import unittest
+import json
+
+from data import (
+    Intel,
+    IntelData,
+    IntelType,
+    Sighting,
+    Operation,
+    IntelEncoder,
+    IntelDecoder,
+    SightingEncoder,
+    SightingDecoder,
+)
+
+
+class TestJsonConversions(unittest.TestCase):
+    def setUp(self):
+        self.ts = datetime.now().astimezone()
+        self.intel_id = "intel-42"
+        self.indicator = "6.6.6.6"
+        self.intel_type = IntelType.IPSRC
+        self.operation = Operation.ADD
+        self.intel_data = IntelData(
+            self.indicator, self.intel_type, foo=23, more_args="MORE ARGS"
+        )
+        self.intel = Intel(self.ts, self.intel_id, self.intel_data, self.operation)
+
+        self.sighting_context = {
+            "ts": "2017-03-03T23:56:09.652643840",
+            "uid": "CMeLkt11aTqwgN4FI9",
+            "id.orig_h": "172.31.130.19",
+            "id.orig_p": 43872,
+            "id.resp_h": "172.31.129.17",
+            "id.resp_p": 20004,
+            "proto": "tcp",
+            "service": None,
+            "duration": 0.025249,
+            "orig_bytes": 311,
+            "resp_bytes": 999,
+            "conn_state": "SF",
+            "local_orig": None,
+            "local_resp": None,
+            "missed_bytes": 0,
+            "history": "ShADadFf",
+            "orig_pkts": 9,
+            "orig_ip_bytes": 787,
+            "resp_pkts": 7,
+            "resp_ip_bytes": 1371,
+            "tunnel_parents": [],
+            "alert": {
+                "signature": "VAST-RETRO Generic IoC match for: 172.31.129.17",
+                "category": "Potentially Bad Traffic",
+                "action": "allowed",
+            },
+            "event_type": "alert",
+            "_extra": {"vast-ioc": "172.31.129.17"},
+            "source": "VAST",
+        }
+        self.sighting = Sighting(self.ts, self.intel_id, self.sighting_context)
+
+    def test_valid_intel_encoding(self):
+        encoded = json.dumps(self.intel, cls=IntelEncoder)
+        # encoding cannot be compared as string, because order of the fileds in
+        # the string representation is not fixed.
+        # We cast the JSON back to a simple python dict and them compare values
+        py_dict = json.loads(encoded)
+        self.assertEqual(py_dict["ts"], str(self.ts))
+        self.assertEqual(py_dict["id"], self.intel_id)
+        self.assertEqual(
+            py_dict["data"],
+            {
+                "foo": 23,
+                "more_args": "MORE ARGS",
+                "indicator": [self.indicator],
+                "intel_type": self.intel_type.value,
+            },
+        )
+
+    def test_valid_intel_decoding(self):
+        encoded = f'{{"ts": "{self.ts}", "id": "intel-42", "data": {{"foo": 23, "more_args": "MORE ARGS", "indicator": ["{self.indicator}"], "intel_type": "{self.intel_type.value}"}}, "operation": "{self.operation.value}"}}'
+        intel = json.loads(encoded, cls=IntelDecoder)
+        self.assertEqual(intel, self.intel)
+
+    def test_intel_encoding_roundtrip(self):
+        encoded = json.dumps(self.intel, cls=IntelEncoder)
+        read_back = json.loads(encoded, cls=IntelDecoder)
+        self.assertEqual(read_back, self.intel)
+
+    def test_valid_sighting_encoding(self):
+        encoded = json.dumps(self.sighting, cls=SightingEncoder)
+        # encoding cannot be compared as string, because order of the fileds in
+        # the string representation is not fixed.
+        # We cast the JSON back to a simple python dict and them compare values
+        py_dict = json.loads(encoded)
+        self.assertEqual(py_dict["ts"], str(self.ts))
+        self.assertEqual(py_dict["intel"], self.intel_id)
+        self.assertEqual(py_dict["context"], self.sighting_context)
+
+    def test_valid_sighting_decoding(self):
+        encoded = f'{{"ts": "{self.ts}", "intel": "{self.intel_id}", "context": {json.dumps(self.sighting_context)}}}'
+        sighting = json.loads(encoded, cls=SightingDecoder)
+        self.assertEqual(sighting, self.sighting)
+
+    def test_sighting_encoding_roundtrip(self):
+        encoded = json.dumps(self.sighting, cls=SightingEncoder)
+        read_back = json.loads(encoded, cls=SightingDecoder)
+        self.assertEqual(read_back, self.sighting)

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -2,7 +2,6 @@ import argparse
 import confuse
 import pluggy
 from queue import Queue
-import time
 from threatbus import appspecs, backbonespecs, logger
 from threatbus.data import MessageType, SnapshotRequest, SnapshotEnvelope
 from threading import Lock
@@ -62,7 +61,6 @@ class ThreatBus:
             message_types.append(MessageType.SIGHTING)
         elif topic.endswith("intel"):
             message_types.append(MessageType.INTEL)
-        snapshot_q = Queue()  # fan-in queue for this particular snapshot
         for mt in message_types:
             self.logger.info(
                 f"Requesting snapshot from all plugins for message type {mt.name} and time delta {time_delta}"

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -111,11 +111,11 @@ class ThreatBus:
 
 
 def validate_config(config):
-    config["logging"]["console"].get(bool)
-    config["logging"]["file"].get(bool)
-    config["logging"]["console_verbosity"].get(str)
-    config["logging"]["file_verbosity"].get(str)
-    config["logging"]["filename"].get(str)
+    if config["logging"]["console"].get(bool):
+        config["logging"]["console_verbosity"].get(str)
+    if config["logging"]["file"].get(bool):
+        config["logging"]["file_verbosity"].get(str)
+        config["logging"]["filename"].get(str)
 
 
 def start(config):

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -16,7 +16,8 @@ class ThreatBus:
         self.inq = Queue()
 
     def request_snapshot(self, topic, dst_q, time_delta):
-        """Request a snapshot from all registered apps for a given topic.
+        """
+        Request a snapshot from all registered apps for a given topic.
         @param topic The topic for which the snapshot is requested
         @param dst_q A queue that should be used to forward all snapshot
             data to

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -114,6 +114,13 @@ def main():
     for unwanted_app in installed_apps - configured_apps:
         tb_logger.info(f"Disabling installed, but unconfigured app '{unwanted_app}'")
         apps.unregister(name=unwanted_app)
+    configured_backbones = set(config["plugins"]["backbones"].keys())
+    installed_backbones = set(dict(backbones.list_name_plugin()).keys())
+    for unwanted_backbones in installed_backbones - configured_backbones:
+        tb_logger.info(
+            f"Disabling installed, but unconfigured backbones '{unwanted_backbones}'"
+        )
+        backbones.unregister(name=unwanted_backbones)
 
     bus = ThreatBus(backbones.hook, apps.hook, tb_logger, config)
     bus.run()


### PR DESCRIPTION
RabbitMQ:
- Implement RabbitMQ backbone plugin
- Add integration test
- Add new types for `SnapshotReqest`s and the transport layer (`SnapshotEnvelope`)

Other:

- Restructure how integration tests are run -> direct invocation of code under test, remove dockerized Threat Bus
- Add GitHub workflow step to run unit-tests w/ `zeek/broker` dependencies
- Use new types for snapshot handling in other plugins