### PR TITLE
Add Whitelist-Filter for IoCs to MISP plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🎁 The generic Threat Bus ZeroMQ application plugin has replaced the former
   VAST plugin. Any app that communicates via ZeroMQ can implement this plugin's
   protocol to connect with Threat Bus effortlessly.
+  [#46](https://github.com/tenzir/threatbus/pull/46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+
+- 🎁 The MISP plugin now supports a whitelist-filtering mechanism. Users can
+  specify required properties of IoCs (MISP attributes) in the configuration
+  file. The filter is implemented for IoCs that are received via ZeroMQ or Kafka
+  as well as IoCs that are requested as part of a snapshot.
+  [#49](https://github.com/tenzir/threatbus/pull/49)
+
 - 🎁 The generic Threat Bus ZeroMQ application plugin has replaced the former
   VAST plugin. Any app that communicates via ZeroMQ can implement this plugin's
   protocol to connect with Threat Bus effortlessly.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -32,6 +32,19 @@ plugins:
         host: https://localhost
         ssl: false
         key: MISP_API_KEY
+      filter: # filter are optional. you can omit the entire section.
+        - orgs: # org IDs must be strings: https://github.com/MISP/PyMISP/blob/main/pymisp/data/schema.json
+            - "1"
+            - "25"
+          tags:
+            - "TLP:AMBER"
+            - "TLP:RED"
+          types: # MISP attribute types https://github.com/MISP/misp-objects/blob/main/schema_objects.json
+            - ip-src
+            - ip-dst
+            - hostname
+            - domain
+            - url
       zmq:
         host: localhost
         port: 50000

--- a/plugins/apps/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/message_mapping.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from threatbus.data import Intel, IntelData, IntelType, Operation, Sighting
 import pymisp
-from typing import Dict
+from typing import Dict, List
 
 
 misp_intel_type_mapping: Dict[str, IntelType] = {
@@ -55,12 +55,65 @@ misp_intel_type_mapping: Dict[str, IntelType] = {
 }
 
 
+def get_tags(misp_attr: dict):
+    """
+    Tags are attached as list of objects to MISP attributes. Returns a list of
+    all tag names.
+    @param The MISP attribute to get the tag names from
+    @return A list of tag names
+    """
+    return [
+        t.get("name", None)
+        for t in misp_attr.get("Tag", [])
+        if t and t.get("name", None)
+    ]
+
+
+def is_whitelisted(misp_msg: dict, filter_config: List[Dict]):
+    """
+    Compares the given MISP message against every filter in the filter_config
+    list. Returns True if the filter_config is empty or if the event is
+    whitelisted according to at least one filter from the filter_config.
+    @param misp_msg The MISP message to check
+    @param filter_config A list of whitelist-filters for "orgs", "tags", and
+        "types"
+    @return Boolean flag to indicate if the event is whitelisted
+    """
+    if not misp_msg:
+        return False
+    event = misp_msg.get("Event", None)
+    attr = misp_msg.get("Attribute", None)
+    if not event or not attr:
+        return False
+    org_id = event.get("org_id", None)
+    intel_type = attr.get("type", None)
+    tags = get_tags(attr)
+    if not org_id or not intel_type:
+        return False
+    if not filter_config:
+        # no whitelist = allow all
+        return True
+    for fil in filter_config:
+        if (
+            (not fil.get("orgs", None) or org_id in fil["orgs"])
+            and (not fil.get("types", None) or intel_type in fil["types"])
+            and (
+                not fil.get("tags", None)
+                or len(set(tags).intersection(set(fil["tags"]))) > 0
+            )
+        ):
+            return True
+    return False
+
+
 def map_to_internal(misp_attribute: dict, action: str, logger=None):
     """
-    Maps the given MISP attribute to the threatbus intel format.
-    @param misp_attribute A MISP attribute
-    @param action A string from MISP, describing the action for the attribute (either 'add' or 'delete')
-    @return the mapped intel item or None
+    Maps the given MISP attribute to the threatbus Intel format. Discards all
+    messages that do not match the given filter, if any.
+    @param misp_attribute The MISP attribute to map
+    @param action A string from MISP, describing the action for the attribute
+        (either 'add' or 'delete')
+    @return The mapped intel item or None
     """
     # parse MISP attribute
     if not misp_attribute:
@@ -87,13 +140,15 @@ def map_to_internal(misp_attribute: dict, action: str, logger=None):
                     f"Expected '|'-separated composite values for MISP intel type {intel_type}"
                 )
             return None
-
+    tb_intel_type = misp_intel_type_mapping.get(intel_type, None)
+    if not tb_intel_type:
+        return None
     return Intel(
         datetime.fromtimestamp(int(misp_attribute["timestamp"])),
         str(misp_attribute["id"]),
         IntelData(
             indicator,
-            misp_intel_type_mapping[intel_type],
+            tb_intel_type,
             source="MISP",
         ),
         operation,

--- a/plugins/apps/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/message_mapping.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from threatbus.data import Intel, IntelData, IntelType, Operation, Sighting
 import pymisp
+from typing import Dict
 
-misp_intel_type_mapping = {
+
+misp_intel_type_mapping: Dict[str, IntelType] = {
     "ip-src": IntelType.IPSRC,
     "ip-dst": IntelType.IPDST,
     "ip-src|port": IntelType.IPSRC_PORT,
@@ -53,7 +55,7 @@ misp_intel_type_mapping = {
 }
 
 
-def map_to_internal(misp_attribute, action, logger=None):
+def map_to_internal(misp_attribute: dict, action: str, logger=None):
     """
     Maps the given MISP attribute to the threatbus intel format.
     @param misp_attribute A MISP attribute
@@ -98,13 +100,13 @@ def map_to_internal(misp_attribute, action, logger=None):
     )
 
 
-def map_to_misp(sighting):
+def map_to_misp(sighting: Sighting):
     """
     Maps the threatbus sighting format to a MISP sighting.
     @param sighting A threatbus Sighting object
     @return the mapped MISP sighting object or None
     """
-    if not sighting or not isinstance(sighting, Sighting):
+    if not sighting or not type(sighting) == Sighting:
         return None
 
     misp_sighting = pymisp.MISPSighting()

--- a/plugins/apps/threatbus_misp/test_message_mapping.py
+++ b/plugins/apps/threatbus_misp/test_message_mapping.py
@@ -1,8 +1,14 @@
 from datetime import datetime
+import json
 import unittest
 
 from threatbus.data import Intel, IntelData, IntelType, Operation, Sighting
-from threatbus_misp.message_mapping import map_to_internal, map_to_misp
+from threatbus_misp.message_mapping import (
+    map_to_internal,
+    map_to_misp,
+    is_whitelisted,
+    get_tags,
+)
 
 
 class TestMessageMapping(unittest.TestCase):
@@ -31,14 +37,75 @@ class TestMessageMapping(unittest.TestCase):
             "disable_correlation": False,
             "value": self.indicator,
             "Sighting": [],
+            "Tag": [],
         }
+        self.valid_misp_msg = json.loads(
+            """{
+        "Attribute": {
+            "id": "1",
+            "event_id": "1",
+            "object_id": "0",
+            "object_relation": null,
+            "category": "Network activity",
+            "type": "ip-src",
+            "value1": "6.6.6.6",
+            "value2": "",
+            "to_ids": true,
+            "uuid": "5f7b2284-bdd8-4ef4-b457-032ac0a82f02",
+            "timestamp": "1601906335",
+            "distribution": "5",
+            "sharing_group_id": "0",
+            "comment": "",
+            "deleted": false,
+            "disable_correlation": false,
+            "first_seen": null,
+            "last_seen": null,
+            "value": "6.6.6.6",
+            "Tag": [
+            {
+                "id": "3",
+                "name": "baz",
+                "colour": "#05ff00",
+                "exportable": true
+            },
+            {
+                "id": "1",
+                "name": "foo",
+                "colour": "#ff0000",
+                "exportable": true
+            }
+            ],
+            "Sighting": []
+        },
+        "Event": {
+            "id": "1",
+            "date": "2020-10-05",
+            "info": "evil",
+            "uuid": "5f7b2277-1ebc-4101-9152-032ac0a82f02",
+            "published": false,
+            "analysis": "0",
+            "threat_level_id": "1",
+            "org_id": "1",
+            "orgc_id": "1",
+            "distribution": "1",
+            "sharing_group_id": "0",
+            "Orgc": {
+            "id": "1",
+            "uuid": "5f7b21ea-52a4-49f0-87df-032ac0a82f02",
+            "name": "ORGNAME"
+            }
+        },
+        "action": "edit"
+        }
+        """
+        )
 
-    def test_invalid_inputs(self):
+    def test_invalid_threatbus_sightings(self):
         self.assertIsNone(map_to_misp(None))
         self.assertIsNone(map_to_misp("Hello"))
         self.assertIsNone(map_to_misp(self))
 
-    def test_invalid_misp_inputs(self):
+    def test_invalid_misp_intel(self):
         self.assertIsNone(map_to_internal(None, None))
         self.assertIsNone(map_to_internal(None, "delete"))
         self.assertIsNone(map_to_internal(self.valid_misp_attribute, None))
@@ -46,13 +113,125 @@ class TestMessageMapping(unittest.TestCase):
     def test_default_action_remove(self):
         self.assertIsNotNone(map_to_internal(self.valid_misp_attribute, "FOOOO"))
 
-    def test_valid_misp_inputs(self):
+    def test_valid_misp_intel(self):
         intel_data = IntelData(self.indicator, self.expected_intel_type, source="MISP")
         expected_intel = Intel(self.ts, self.id, intel_data, Operation.ADD)
         self.assertEqual(
             map_to_internal(self.valid_misp_attribute, "add"), expected_intel
         )
 
-    def test_valid_inputs(self):
+    def test_valid_threatbus_sighting(self):
         sighting = Sighting(self.ts, self.id, {}, (self.indicator,))
         self.assertIsNotNone(map_to_misp(sighting))
+
+    def test_invalid_tags(self):
+        attr = self.valid_misp_msg["Attribute"]
+        del attr["Tag"]
+        tags = get_tags(attr)
+        self.assertEqual(tags, [])
+
+        attr["Tag"] = []
+        tags = get_tags(attr)
+        self.assertEqual(tags, [])
+
+        attr["Tag"] = [{"some": "property"}]
+        tags = get_tags(attr)
+        self.assertEqual(tags, [])
+
+    def test_valid_tags(self):
+        attr = self.valid_misp_msg["Attribute"]
+        tags = get_tags(attr)
+        self.assertEqual(sorted(tags), sorted(["foo", "baz"]))
+
+    def test_invalid_message_is_whitelisted(self):
+        event = self.valid_misp_msg["Event"]
+        filter_config = {}  # nothing whitelisted means everything is whitelisted
+
+        del self.valid_misp_msg["Event"]
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        self.valid_misp_msg["Event"] = event
+        del self.valid_misp_msg["Attribute"]
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+    def test_valid_message_is_whitelisted(self):
+
+        # positive tests with one filter:
+        filter_config = []
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1", "100"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["foo", "ASDF"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"types": ["domain", "ip-src"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"], "tags": ["foo"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"], "types": ["ip-src"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["foo"], "types": ["ip-src"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"], "tags": ["foo"], "types": ["ip-src"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        # positive tests with multiple filters where only one matches
+        filter_config = [{"orgs": ["1"]}, {"orgs": ["5"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"]}, {"types": ["ASDF"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["foo"]}, {"types": ["ASDF"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        # positive tests with multiple filters where many match
+        filter_config = [{"tags": ["foo"]}, {"types": ["ip-src"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["baz"]}, {"org": ["1"]}]
+        self.assertTrue(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        # negative tests with one filter:
+        filter_config = [{"orgs": ["100"]}]  # org doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["ASDF"]}]  # tag doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"types": ["domain"]}]  # type doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"], "tags": ["ASDF"]}]  # tag doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"types": ["ip-src"], "tags": ["ASDF"]}]  # tag doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["1"], "types": ["domain"]}]  # type doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["foo"], "types": ["domain"]}]  # type doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"types": ["src-ip"], "orgs": ["100"]}]  # org doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["foo"], "orgs": ["100"]}]  # org doesn't match
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        # negative tests with multiple filters where none matches
+        filter_config = [{"orgs": ["100"]}, {"orgs": ["5"]}]
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"orgs": ["100"]}, {"types": ["ASDF"]}]
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))
+
+        filter_config = [{"tags": ["ASDF"]}, {"types": ["ASDF"]}]
+        self.assertFalse(is_whitelisted(self.valid_misp_msg, filter_config))


### PR DESCRIPTION
This PR adds a whitelist-filtering mechanism to the MISP plugin. Administrators can define desired properties of IoCs (MISP attributes) in the configuration, and the plugin will forward only those IoCs to Threat Bus that match the configured properties.

The filter is implemented for IoCs that are received via ZeroMQ / Kafka as well as IoCs that are queried as part of a snapshot.