### PR TITLE
Handle two common timestamp field names

### DIFF
--- a/apps/vast/message_mapping.py
+++ b/apps/vast/message_mapping.py
@@ -99,8 +99,11 @@ def query_result_to_threatbus_sighting(query_result: str, intel: Intel):
     try:
         context = json.loads(query_result)
         context["source"] = "VAST"
+        ts = context.get("ts", context.get("timestamp", None))
+        if not ts:
+            return None
         return Sighting(
-            dateutil_parser.parse(context.get("ts", None)),
+            dateutil_parser.parse(ts),
             intel.id,
             context,
             get_ioc(intel),

--- a/apps/vast/test_message_mapping.py
+++ b/apps/vast/test_message_mapping.py
@@ -30,7 +30,7 @@ class TestMessageMapping(unittest.TestCase):
         self.valid_intel = Intel(
             self.ts, self.id, self.valid_intel_data, self.operation
         )
-        self.valid_query_result = f'{{"ts": "{self.ts}", "uid": "CArLTF3OEJAsF1A41h", "id.orig_h": "{self.indicator[0]}", "id.orig_p": "20004/tcp", "id.resp_h": "172.31.129.37", "id.resp_p": "40731/tcp", "proto": "tcp", "service": null, "duration": "10.75ms", "orig_bytes": 260, "resp_bytes": 352, "conn_state": "SF", "local_orig": null, "local_resp": null, "missed_bytes": 0, "history": "DadAFf", "orig_pkts": 5, "orig_ip_bytes": 520, "resp_pkts": 5, "resp_ip_bytes": 612, "tunnel_parents": []}}'
+        self.valid_query_result = f'{{"timestamp": "{self.ts}", "uid": "CArLTF3OEJAsF1A41h", "id.orig_h": "{self.indicator[0]}", "id.orig_p": "20004/tcp", "id.resp_h": "172.31.129.37", "id.resp_p": "40731/tcp", "proto": "tcp", "service": null, "duration": "10.75ms", "orig_bytes": 260, "resp_bytes": 352, "conn_state": "SF", "local_orig": null, "local_resp": null, "missed_bytes": 0, "history": "DadAFf", "orig_pkts": 5, "orig_ip_bytes": 520, "resp_pkts": 5, "resp_ip_bytes": 612, "tunnel_parents": []}}'
         self.valid_vast_sighting = f'{{"ts": "{self.ts}", "data_id": 8, "indicator_id": 5, "matcher": "threatbus-syeocdkfcy", "ioc": "{self.indicator[0]}", "reference": "threatbus__{self.id}"}}'
         self.invalid_intel_1 = {
             "ts": self.ts,


### PR DESCRIPTION
The bridge wrongly assumed that all timestamp fields in VAST results would be named `ts`. Now, the bridge additionally supports fields named `timestamp`.