### PR TITLE
Allow startup without API connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Every entry has a category for which we use the following visual abbreviations:
 ## Unreleased
 
 - 🎁 The MISP plugin does not require an API connection anymore. If omitted, the
-  plugin can still receive IoCs normally, but it cannot report back Sightings or
-  request Snapshots.
+  plugin can still receive IoCs normally, but it cannot report back sightings or
+  request snapshots.
   [#55](https://github.com/tenzir/threatbus/pull/55)
 
 - 🎁 The MISP plugin now supports a whitelist-filtering mechanism. Users can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 The MISP plugin does not require an API connection anymore. If omitted, the
+  plugin can still receive IoCs normally, but it cannot report back Sightings or
+  request Snapshots.
+  [#55](https://github.com/tenzir/threatbus/pull/55)
 
 - 🎁 The MISP plugin now supports a whitelist-filtering mechanism. Users can
   specify required properties of IoCs (MISP attributes) in the configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🎁 The MISP plugin does not require an API connection anymore. If omitted, the
-  plugin can still receive IoCs normally, but it cannot report back sightings or
-  request snapshots.
+- 🎁 The MISP plugin now works without a valid PyMISP API connection. If omitted in the configuration, the plugin can still receive indicators via ZeroMQ or Kafka, but it cannot report back sightings or request snapshots.
   [#55](https://github.com/tenzir/threatbus/pull/55)
 
 - 🎁 The MISP plugin now supports a whitelist-filtering mechanism. Users can

--- a/plugins/apps/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/plugin.py
@@ -205,6 +205,7 @@ def run(
     filter_config = config["filter"].get(list)
 
     # start Attribute-update receiver
+    receiver_thread = None
     if config["zmq"].get():
         receiver_thread = threading.Thread(
             target=receive_zmq, args=(config["zmq"], inq), daemon=True
@@ -244,5 +245,6 @@ def run(
     outq = Queue()
     subscribe_callback("threatbus/sighting", outq)
     threading.Thread(target=publish_sightings, args=(outq,), daemon=True).start()
-    receiver_thread.start()
+    if receiver_thread is not None:
+        receiver_thread.start()
     logger.info("MISP plugin started")

--- a/plugins/apps/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/plugin.py
@@ -143,6 +143,7 @@ def snapshot(snapshot_request: SnapshotRequest, result_q: Queue):
         logger.debug("Sighting snapshot feature not yet implemented.")
         return  # TODO sighting snapshot not yet implemented
     if not misp:
+        logger.debug("Cannot perform snapshot request. No MISP API connection.")
         return
 
     logger.info(f"Executing intel snapshot for time delta {snapshot_request.snapshot}")
@@ -200,7 +201,24 @@ def run(
         validate_config(config)
     except Exception as e:
         logger.fatal("Invalid config for plugin {}: {}".format(plugin_name, str(e)))
-    if config["api"].get():
+
+    filter_config = config["filter"].get(list)
+
+    # start Attribute-update receiver
+    if config["zmq"].get():
+        receiver_thread = threading.Thread(
+            target=receive_zmq, args=(config["zmq"], inq), daemon=True
+        )
+    elif config["kafka"].get():
+        receiver_thread = threading.Thread(
+            target=receive_kafka, args=(config["kafka"], inq), daemon=True
+        )
+
+    # bind to MISP
+    if config["api"].get(dict):
+        # TODO: MISP instances shall subscribe themselves to threatbus and each
+        # subscription shall have an individual outq and receiving thread for intel
+        # updates.
         host, key, ssl = (
             config["api"]["host"].get(),
             config["api"]["key"].get(),
@@ -215,23 +233,16 @@ def run(
             # TODO: log individual error per MISP subscriber
             logger.error(f"Cannot subscribe to MISP at {host}, using SSL: {ssl}")
             lock.release()
-    filter_config = config["filter"].get(list)
-    # TODO: MISP instances shall subscribe themselves to threatbus and each
-    # subscription shall have an individual outq and receiving thread for intel
-    # updates.
+        if not misp:
+            logger.error("Failed to start MISP plugin")
+            return
+    else:
+        logger.warning(
+            "Starting MISP plugin without API connection, cannot report back sightings or request snapshots."
+        )
+
     outq = Queue()
     subscribe_callback("threatbus/sighting", outq)
-
-    if not misp:
-        logger.error("Failed to start up MISP plugin")
-        return
     threading.Thread(target=publish_sightings, args=(outq,), daemon=True).start()
-    if config["zmq"].get():
-        threading.Thread(
-            target=receive_zmq, args=(config["zmq"], inq), daemon=True
-        ).start()
-    if config["kafka"].get():
-        threading.Thread(
-            target=receive_kafka, args=(config["kafka"], inq), daemon=True
-        ).start()
+    receiver_thread.start()
     logger.info("MISP plugin started")


### PR DESCRIPTION
The MISP plugin can now be started without the need to configure a valid `api` connection. If the configuration is present, it is checked for validity (as before). If omitted, the plugin can still receive attribute updates from MISP via ZMQ or Kafka, but it cannot report back Sightings or execute Snapshot requests.

