### PR TITLE
Add config file support to vast-bridge.py

### DIFF
--- a/apps/vast/README.md
+++ b/apps/vast/README.md
@@ -22,32 +22,45 @@ python3 -m pip install -r requirements.txt
 
 ## Quick Start
 
-The bridge gets configured via command line arguments and flags. Inspect the
-command help as follows.
+The bridge is configured either via a config file in YAML format or via command
+line arguments and flags. See `config.yaml.example` for an example configuration
+file that make use of [fever alertify](https://github.com/DCSO/fever) to
+transform sighting contexts before they get printed to `STDOUT`. See the section
+[Bridge Features](/tenzir/threatbus/tree/master/apps/vast#bridge-features) for
+details. Or inspect the command help as follows.
 
 ```sh
-./vast-bridge --help
+./vast-bridge.py --help
+```
+
+Start with a config file.
+
+```sh
+./vast-bridge.py -c config.yaml
 ```
 
 Startup with debug logging and customized endpoints for Threat Bus and VAST.
 
 ```sh
-./vast-bridge --vast-binary=/opt/tenzir/bin/vast --vast=localhost:42000 --threatbus=localhost:13370 --loglevel=DEBUG
+./vast-bridge.py --vast-binary=/opt/tenzir/bin/vast --vast=localhost:42000 --threatbus=localhost:13370 --loglevel=DEBUG
 ```
 
-Request an intelligence snapshot of the past 50 days.
+Request an intelligence snapshot of the past 50 days and match it
+retrospectively against the entire VAST database.
 
 ```sh
-./vast-bridge.py --snapshot=50
+./vast-bridge.py --snapshot=50 --retro-match
 ```
 
 ## Bridge Features
 
-This section explains the most important features and CLI options of the `vast-bridge`.
+This section explains the most important features and CLI options of the
+`vast-bridge`.
 
 ### IoC Matching
 
-VAST can match IoCs either live or retrospectively via usual queries.
+[VAST](https://github.com/tenzir/vast) can match IoCs either live or
+retrospectively via usual queries.
 
 #### Live Matching
 
@@ -65,7 +78,7 @@ that the VAST node must support this feature.
 
 The `vast-bridge` supports retro matching via the command line option
 `--retro-match`. This instructs the bridge to translate IoCs from
-Threat Bus to VAST queries instead of feeding the IoCs to a live matcher.
+Threat Bus to normal VAST queries instead of feeding the IoCs to a live matcher.
 
 Each result from an IoC query is treated as `Sighting` of that IoC and reported
 back to Threat Bus.
@@ -80,7 +93,7 @@ field of a Sighting via the specified utility. For example, pass the `context`
 object to [DCSO/fever](https://github.com/DCSO/fever) `alertify`:
 
 ```
-apps/vast/vast-bridge.py --retro-match --transform-context "fever alertify --alert-prefix VAST-RETRO --extra-key vast-ioc --ioc %ioc"
+apps/vast/vast-bridge.py --retro-match --transform-context "fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc"
 ```
 
 A `Sighting` object is structured as follows:
@@ -111,7 +124,7 @@ _instead_ of reporting them back to Threat Bus. This can be configured via the
 Sighting context to `STDOUT`. Example:
 
 ```
-apps/vast/vast-bridge.py --sink stdout
+./vast-bridge.py --sink stdout
 ```
 
 A custom sink is useful to forward `Sightings` to another process, like

--- a/apps/vast/README.md
+++ b/apps/vast/README.md
@@ -22,31 +22,28 @@ python3 -m pip install -r requirements.txt
 
 ## Quick Start
 
-The bridge is configured either via a config file in YAML format or via command
-line arguments and flags. See `config.yaml.example` for an example configuration
-file that make use of [fever alertify](https://github.com/DCSO/fever) to
-transform sighting contexts before they get printed to `STDOUT`. See the section
+You can configure the bridge either via YAML config file or via command line
+arguments. See `config.yaml.example` for an example configuration file that uses
+[fever alertify](https://github.com/DCSO/fever) to transform sighting contexts
+before they get printed to `STDOUT`. See the section
 [Bridge Features](/tenzir/threatbus/tree/master/apps/vast#bridge-features) for
-details. Or inspect the command help as follows.
+details and `--help` for command line usage. Here are some command line options
+to get you started.
 
-```sh
-./vast-bridge.py --help
-```
-
-Start with a config file.
+Start with a config file:
 
 ```sh
 ./vast-bridge.py -c config.yaml
 ```
 
-Startup with debug logging and customized endpoints for Threat Bus and VAST.
+Startup with debug logging and customized endpoints for Threat Bus and VAST:
 
 ```sh
 ./vast-bridge.py --vast-binary=/opt/tenzir/bin/vast --vast=localhost:42000 --threatbus=localhost:13370 --loglevel=DEBUG
 ```
 
 Request an intelligence snapshot of the past 50 days and match it
-retrospectively against the entire VAST database.
+retrospectively against the entire VAST database:
 
 ```sh
 ./vast-bridge.py --snapshot=50 --retro-match

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -1,9 +1,11 @@
 vast: "localhost:42000"
-vast_binary: "vast"
+vast_binary: vast
 threatbus: "localhost:13370"
 snapshot: 30
 loglevel: DEBUG
 retro_match: true
 unflatten: true
-transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc # optional. remove the field if you don't want to transform sighting context
-sink: STDOUT # optional. remove the field if you simply want to report back sightings to Threat Bus
+# optional. remove the field if you don't want to transform sighting context
+transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc
+# optional. remove the field if you simply want to report back sightings to Threat Bus
+sink: STDOUT

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -1,0 +1,9 @@
+vast: "localhost:42000"
+vast_binary: "vast"
+threatbus: "localhost:13370"
+snapshot: 30
+loglevel: DEBUG
+retro_match: true
+unflatten: true
+transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc # optional. remove the field if you don't want to transform sighting context
+sink: STDOUT # optional. remove the field if you simply want to report back sightings to Threat Bus

--- a/apps/vast/requirements.txt
+++ b/apps/vast/requirements.txt
@@ -1,4 +1,5 @@
 coloredlogs>=14.0
+confuse
 pyzmq>=19
 pyvast>=2020.8.28
 threatbus>=2020.9.30

--- a/apps/vast/vast-bridge.py
+++ b/apps/vast/vast-bridge.py
@@ -493,7 +493,7 @@ def main():
     try:
         validate_config(config)
     except Exception as e:
-        raise ValueError("Invalid config: {}".format(str(e)))
+        raise ValueError(f"Invalid config: {e}")
 
     setup_logging(config["loglevel"].get(str))
     asyncio.run(

--- a/apps/vast/vast-bridge.py
+++ b/apps/vast/vast-bridge.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import atexit
 import coloredlogs
+import confuse
 from datetime import datetime
 import json
 import logging
@@ -39,6 +40,21 @@ def setup_logging(level):
         logger.setLevel(log_level)
     handler.setFormatter(colored_formatter)
     logger.addHandler(handler)
+
+
+def validate_config(config: confuse.Subview):
+    assert config, "config must not be None"
+    config["vast"].get(str)
+    config["vast_binary"].get(str)
+    config["threatbus"].get(str)
+    config["snapshot"].get(int)
+    config["loglevel"].get(str)
+    config["retro_match"].get(bool)
+    config["unflatten"].get(bool)
+
+    # fallback values for the optional arguments
+    config["transform_context"].add(None)
+    config["sink"].add(None)
 
 
 async def start(
@@ -404,6 +420,7 @@ def unsubscribe(endpoint: str, topic: str, timeout: int = 5):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--config", "-c", help="Path to a configuration file")
     parser.add_argument(
         "--vast",
         "-v",
@@ -414,7 +431,7 @@ def main():
     parser.add_argument(
         "--vast-binary",
         "-b",
-        dest="binary",
+        dest="vast_binary",
         default="vast",
         help="The vast command to use (either absolte path or a command available in $PATH)",
     )
@@ -436,7 +453,7 @@ def main():
     parser.add_argument(
         "--loglevel",
         "-l",
-        dest="log_level",
+        dest="loglevel",
         default="info",
         help="Loglevel to use for the bridge",
     )
@@ -455,7 +472,7 @@ def main():
     parser.add_argument(
         "--transform-context",
         "-T",
-        dest="transform",
+        dest="transform_context",
         default=None,
         help="Forward the context of each sighting (only the contents without the Threat Bus specific sighting structure) via a UNIX pipe. This option takes a command line string to use and invokes it as direct subprocess without shell / globbing support. Note: Treated as template string. Occurrences of '%%ioc' get replaced with the matched IoC.",
     )
@@ -466,20 +483,29 @@ def main():
         default=None,
         help="If sink is specified, sightings are not reported back to Threat Bus. Instead, the context of a sighting (only the contents without the Threat Bus specific sighting structure) is forwarded to the specified sink via a UNIX pipe. This option takes a command line string to use and invokes it as direct subprocess without shell / globbing support.",
     )
-
     args = parser.parse_args()
 
-    setup_logging(args.log_level)
+    config = confuse.Configuration("vast-bridge")
+    config.set_args(args)
+    if args.config:
+        config.set_file(args.config)
+
+    try:
+        validate_config(config)
+    except Exception as e:
+        raise ValueError("Invalid config: {}".format(str(e)))
+
+    setup_logging(config["loglevel"].get(str))
     asyncio.run(
         start(
-            args.binary,
-            args.vast,
-            args.threatbus,
-            args.snapshot,
-            args.retro_match,
-            args.unflatten,
-            args.transform,
-            args.sink,
+            config["vast_binary"].get(),
+            config["vast"].get(),
+            config["threatbus"].get(),
+            config["snapshot"].get(),
+            config["retro_match"].get(),
+            config["unflatten"].get(),
+            config["transform_context"].get(),
+            config["sink"].get(),
         )
     )
 


### PR DESCRIPTION
The `vast-bridge.py` can now be configured with a `config.yaml` file or via command-line arguments.