### PR TITLE
ZMQ-App Heartbeats & vast-bridge reconnect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 The `zmq-app` plugin now supports synchronous heartbeats. With heartbeats,
+  both Threat Bus and the connected apps can mutually ensure that the connected
+  party is still alive.
+  [#58](https://github.com/tenzir/threatbus/pull/58)
 
 ## [2020.10.29]
 
-- 🎁 The MISP plugin now works without a valid PyMISP API connection. If omitted in the configuration, the plugin can still receive indicators via ZeroMQ or Kafka, but it cannot report back sightings or request snapshots.
+- 🎁 The MISP plugin now works without a valid PyMISP API connection. If omitted
+  in the configuration, the plugin can still receive indicators via ZeroMQ or
+  Kafka, but it cannot report back sightings or request snapshots.
   [#55](https://github.com/tenzir/threatbus/pull/55)
 
 - 🎁 The MISP plugin now supports a whitelist-filtering mechanism. Users can

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ integration-tests:
 	-python -m unittest tests/integration/test_message_roundtrips.py
 	-python -m unittest tests/integration/test_zeek_app.py
 	-python -m unittest tests/integration/test_rabbitmq.py
+	-python -m unittest tests/integration/test_zmq_app_management.py
 	-${RM} {broker,intel,reporter,weird}.log
 	docker kill rabbit-int > /dev/null 2>&1
 

--- a/plugins/apps/threatbus_zmq_app/README.md
+++ b/plugins/apps/threatbus_zmq_app/README.md
@@ -107,7 +107,7 @@ endpoint of the plugin, as follows:
 ```
 {
   "action": "unsubscribe",
-  "topic": <P2P_TOPIC>       # the 32-characters random topic that the got during subscription handshake
+  "topic": <P2P_TOPIC>       # the 32-characters random topic that the app got during subscription handshake
 }
 ```
 
@@ -125,6 +125,48 @@ In response, the app will either receive a `success` or `error` response.
     "status": "success"
   }
   ```
+
+### Heartbeats
+
+The plugin supports synchronous heartbeats from subscribed apps. Both, Threat
+Bus and the connected apps benefit from heartbeats, they can mutually ensure
+that the connected party is still alive.
+
+Subscribed apps can send heartbeat messages with the following JSON format to
+the `manage` endpoint of this plugin:
+
+```
+{
+  "action": "heartbeat",
+  "topic": <P2P_TOPIC>       # the 32-characters random topic that the app got during subscription handshake
+}
+```
+
+As stated in the beginning of this section, the `manage` endpoint implements the
+[ZeroMQ Request/Reply](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html)
+pattern. Threat Bus answers immediately to each heartbeat request with either a
+`success` or `error` response.
+
+- Error response:
+  ```
+  {
+    "status": "error"
+  }
+  ```
+- Success response:
+  ```
+  {
+    "status": "success"
+  }
+  ```
+
+An `error` response indicates that either Threat Bus has internal erros or that
+it lost track of the app's subscription. Note: This only happens when Threat Bus
+is restarted. Apps can then use that information to re-subscribe.
+
+If Threat Bus does not answer a heartbeat message, it is either down or not
+reachable (e.g., due to network issues). Plugins can use that information to try
+again later.
 
 ### Pub/Sub via ZeroMQ
 

--- a/plugins/apps/threatbus_zmq_app/message_mapping.py
+++ b/plugins/apps/threatbus_zmq_app/message_mapping.py
@@ -1,5 +1,11 @@
+from dataclasses import dataclass
 from datetime import timedelta
 from threatbus.data import Subscription, Unsubscription
+
+
+@dataclass
+class Heartbeat:
+    topic: str
 
 
 def map_management_message(msg):
@@ -11,7 +17,9 @@ def map_management_message(msg):
     topic = msg.get("topic", None)
     snapshot = msg.get("snapshot", 0)
     snapshot = timedelta(days=int(snapshot))
-    if action == "subscribe" and topic is not None and snapshot is not None:
+    if action == "heartbeat" and topic:
+        return Heartbeat(topic)
+    if action == "subscribe" and topic and snapshot is not None:
         return Subscription(topic, snapshot)
-    elif action == "unsubscribe" and topic is not None:
+    elif action == "unsubscribe" and topic:
         return Unsubscription(topic)

--- a/plugins/apps/threatbus_zmq_app/test_message_mapping.py
+++ b/plugins/apps/threatbus_zmq_app/test_message_mapping.py
@@ -5,33 +5,36 @@ from threatbus.data import (
     Subscription,
     Unsubscription,
 )
-from threatbus_zmq_app.message_mapping import map_management_message
+from threatbus_zmq_app.message_mapping import Heartbeat, map_management_message
 
 
 class TestMessageMapping(unittest.TestCase):
-    def test_valid_subscription(self):
-        topic = "some/topic"
+    def setUp(self):
+        self.topic = "some/topic"
 
+    def test_valid_subscription(self):
         # without snapshot
-        msg = {"action": "subscribe", "topic": topic}
+        msg = {"action": "subscribe", "topic": self.topic}
         td = timedelta(0)
         subscription = map_management_message(msg)
-        expected = Subscription(topic, td)
+        expected = Subscription(self.topic, td)
         self.assertEqual(subscription, expected)
 
         # with snapshot:
-        msg = {"action": "subscribe", "snapshot": 17, "topic": topic}
+        msg = {"action": "subscribe", "snapshot": 17, "topic": self.topic}
         td = timedelta(17)
         subscription = map_management_message(msg)
-        expected = Subscription(topic, td)
+        expected = Subscription(self.topic, td)
         self.assertEqual(subscription, expected)
 
     def test_valid_unsubscription(self):
-        topic = "some/topic"
-        expected = Unsubscription(topic)
-
-        # with snapshot:
-        msg = {"action": "unsubscribe", "topic": topic}
+        msg = {"action": "unsubscribe", "topic": self.topic}
         unsub = map_management_message(msg)
-        expected = Unsubscription(topic)
+        expected = Unsubscription(self.topic)
         self.assertEqual(unsub, expected)
+
+    def test_valid_heartbeat(self):
+        msg = {"action": "heartbeat", "topic": self.topic}
+        hb = map_management_message(msg)
+        expected = Heartbeat(self.topic)
+        self.assertEqual(hb, expected)

--- a/tests/integration/test_zmq_app_management.py
+++ b/tests/integration/test_zmq_app_management.py
@@ -1,0 +1,154 @@
+import confuse
+import json
+import threading
+from threatbus import start
+import time
+import unittest
+import zmq
+
+
+def send_manage_message(endpoint: str, msg: str, timeout: int = 5):
+    """
+    Helper function to send a 'management' message, following the zmq-app
+    protocol.
+    @param endpoint A host:port string to connect to via ZeroMQ
+    @param msg The message to send as raw String
+    @param timeout The period after which the connection attempt is aborted
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.REQ)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.connect(f"tcp://{endpoint}")
+    socket.send_string(msg)
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
+
+    reply = None
+    if poller.poll(timeout * 1000):
+        reply = socket.recv_json()
+    socket.close()
+    context.term()
+    return reply
+
+
+class TestMessageRoundtrip(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestMessageRoundtrip, cls).setUpClass()
+        config = confuse.Configuration("threatbus")
+        config.set_file("config_integration_test.yaml")
+        cls.threatbus = threading.Thread(
+            target=start,
+            args=(config,),
+            daemon=True,
+        )
+        cls.threatbus.start()
+        time.sleep(1)
+
+    def setUp(self):
+        self.endpoint = "localhost:13370"
+        self.topic = "TOPIC"
+        self.valid_heartbeat = {"action": "heartbeat", "topic": self.topic}
+        self.valid_subscription = {"action": "subscribe", "topic": self.topic}
+        self.valid_unsubscription = {"action": "unsubscribe", "topic": self.topic}
+
+    def test_zmq_app_management_endpoint_failure(self):
+        """
+        Sends invalid messages to the management endpoint.
+        """
+        ## JSON message, but not according to protocol
+        invalid_msg = {"action": "FOO"}
+        reply = send_manage_message(self.endpoint, json.dumps(invalid_msg))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "unknown request")
+
+        ## no JSON-formatted message
+        reply = send_manage_message(self.endpoint, "FOO")
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "error")
+
+    def test_zmq_app_plugin_heartbeat_failure(self):
+        """
+        Sends heartbeat messages to the management endpoint that lead to errors.
+        """
+        ## heartbeat without 'topic' field
+        invalid_heartbeat = {"action": "heartbeat"}
+        reply = send_manage_message(self.endpoint, json.dumps(invalid_heartbeat))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "unknown request")
+
+        ## valid heartbeat, but nobody is subscribed for TOPIC
+        reply = send_manage_message(self.endpoint, json.dumps(self.valid_heartbeat))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "error")
+
+    def test_zmq_app_plugin_subscription_failure(self):
+        """
+        Sends subscription messages to the management endpoint that lead to
+        errors.
+        """
+        ## subscription without 'topic' field
+        invalid_subscription = {"action": "subscribe"}
+        reply = send_manage_message(self.endpoint, json.dumps(invalid_subscription))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "unknown request")
+
+        ## subscription with malicious 'snapshot' field
+        invalid_subscription = {
+            "action": "subscribe",
+            "topic": self.topic,
+            "snapshot": "FOO",
+        }
+        reply = send_manage_message(self.endpoint, json.dumps(invalid_subscription))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "error")
+
+    def test_zmq_app_plugin_unsubscription_failure(self):
+        """
+        Sends unsubscription messages to the management endpoint that lead to
+        errors.
+        """
+        ## unsubscription without 'topic' field
+        invalid_unsubscription = {"action": "unsubscribe"}
+        reply = send_manage_message(self.endpoint, json.dumps(invalid_unsubscription))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "unknown request")
+
+        ## valid unsubscription, but nobody is subscribed for TOPIC
+        reply = send_manage_message(
+            self.endpoint, json.dumps(self.valid_unsubscription)
+        )
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "error")
+
+    def test_zmq_app_plugin_full_roundtrip_success(self):
+        """
+        Sends a successful subscription, then heartbeat, then unsubscribes via
+        the management endpoint.
+        """
+        reply = send_manage_message(self.endpoint, json.dumps(self.valid_subscription))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "success")
+        self.assertIsNotNone(reply["topic"])
+        self.assertEquals(reply["pub_endpoint"], "127.0.0.1:13371")
+        self.assertEquals(reply["sub_endpoint"], "127.0.0.1:13372")
+
+        p2p_topic = reply["topic"]  # needed for heartbeat and unsubscription
+        self.valid_heartbeat["topic"] = p2p_topic
+        self.valid_unsubscription["topic"] = p2p_topic
+
+        reply = send_manage_message(self.endpoint, json.dumps(self.valid_heartbeat))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "success")
+
+        reply = send_manage_message(
+            self.endpoint, json.dumps(self.valid_unsubscription)
+        )
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "success")
+
+        # assert that nobody is subscribed for p2p_topic anymore, so another
+        # heartbeat with that topic must error
+        reply = send_manage_message(self.endpoint, json.dumps(self.valid_heartbeat))
+        self.assertTrue(type(reply) is dict)
+        self.assertEquals(reply["status"], "error")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Add heatbeat feature to `zmq-app` plugin.
- Implement heartbeats in `vast-bridge`
- Reconnect `vast-bridge` on heartbeat failure

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com](https://docs.tenzir.com), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
Commit-by-commit