### PR TITLE
Use concept queries over suffix queries

### DIFF
--- a/apps/vast/message_mapping.py
+++ b/apps/vast/message_mapping.py
@@ -78,14 +78,9 @@ def to_vast_query(intel: Intel):
     if vast_type == "ip":
         return str(indicator)
     if vast_type == "url":
-        # TODO: use field annotations, once implemented (ch17531)
-        return f'"{indicator}" in url'
+        return f'"{indicator}" in net.uri'
     if vast_type == "domain":
-        # Currently, uses VAST's suffix-based field matching. Targets every
-        # schema with fieldnames that end in `domain`, `host`, or `hostname`
-        # (Zeek and Suricata)
-        # TODO: use field annotations, once implemented (ch17531)
-        return f'"{indicator}" in domain || "{indicator}" in host || "{indicator}" in hostname'
+        return f'"{indicator}" in net.domain || "{indicator}" in net.hostname'
     return None
 
 

--- a/apps/vast/test_message_mapping.py
+++ b/apps/vast/test_message_mapping.py
@@ -181,7 +181,7 @@ class TestMessageMapping(unittest.TestCase):
         url = "https://example.com/foo/bar"
         intel_data = IntelData(url, IntelType.URL)
         intel = Intel(self.ts, self.id, intel_data, self.operation)
-        self.assertEqual(to_vast_query(intel), f'"{url}" in url')
+        self.assertEqual(to_vast_query(intel), f'"{url}" in net.uri')
 
         # Domain type
         domain = "example.com"
@@ -189,7 +189,7 @@ class TestMessageMapping(unittest.TestCase):
         intel = Intel(self.ts, self.id, intel_data, self.operation)
         self.assertEqual(
             to_vast_query(intel),
-            f'"{domain}" in domain || "{domain}" in host || "{domain}" in hostname',
+            f'"{domain}" in net.domain || "{domain}" in net.hostname',
         )
 
     def test_valid_query_result_to_threatbus_sighting(self):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR depends on https://github.com/tenzir/vast/pull/1161

Rewrite suffix-based VAST queries to concept queries instead.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
