### PR TITLE
Fix Zeek app in cluster mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The Zeek app did not perform an outbound connection to Threat Bus in
+  cluster mode. Now the master peers with Threat Bus to establish a connection.
+  [#68](https://github.com/tenzir/threatbus/pull/68)
+
 - 🎁 The `zmq-app` and `zeek` plugins now use the Unix select system call for
   improved performance during message passing. The previous approach impacted
   the performance with a constant delay for every message and did not scale.

--- a/apps/zeek/threatbus.zeek
+++ b/apps/zeek/threatbus.zeek
@@ -126,14 +126,13 @@ event zeek_init() &priority=1
   }
 @endif
 
-# If we operate in a cluster setting, we do not need to open another socket but
-# instead communicate over the already existing one. The endpoint for that is
-# Broker::default_listen_address and Broker::default_port
-@if ( ! Cluster::is_enabled() )
+# The manager peers with Threat Bus.
+@if ( ! Cluster::is_enabled()
+      || Cluster::local_node_type() == Cluster::MANAGER )
 event zeek_init() &priority=0
   {
   if ( log_operations )
-    Reporter::info(fmt("peering to threatbus at %s:%s",
+    Reporter::info(fmt("peering with threatbus at %s:%s",
                        broker_host, broker_port));
   Broker::peer(broker_host, broker_port, 5sec);
   }


### PR DESCRIPTION
This PR fixes an issue where the Zeek app fails to initiate a connection to Threat Bus when running in cluster mode.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

In one shot.
