### PR TITLE
Fix thread termination behavior for Python <= 3.7.3

### DIFF
--- a/plugins/apps/threatbus_cif3/threatbus_cif3/plugin.py
+++ b/plugins/apps/threatbus_cif3/threatbus_cif3/plugin.py
@@ -121,5 +121,8 @@ def run(
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("CIF3 plugin stopped")

--- a/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
@@ -282,5 +282,8 @@ def run(
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("MISP plugin stopped")

--- a/plugins/apps/threatbus_zeek/threatbus_zeek/plugin.py
+++ b/plugins/apps/threatbus_zeek/threatbus_zeek/plugin.py
@@ -216,5 +216,8 @@ def run(
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("Zeek plugin stopped")

--- a/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/plugin.py
+++ b/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/plugin.py
@@ -323,5 +323,8 @@ def run(
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("ZeroMQ app plugin stopped")

--- a/plugins/backbones/threatbus_inmem/threatbus_inmem/plugin.py
+++ b/plugins/backbones/threatbus_inmem/threatbus_inmem/plugin.py
@@ -86,5 +86,8 @@ def run(config: Subview, logging: Subview, inq: JoinableQueue):
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("In-memory backbone stopped")

--- a/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/plugin.py
+++ b/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/plugin.py
@@ -118,5 +118,8 @@ def run(config: Subview, logging: Subview, inq: JoinableQueue):
 def stop():
     global logger, workers
     for w in workers:
+        if not w.is_alive():
+            continue
+        w.stop()
         w.join()
     logger.info("RabbitMQ backbone stopped")

--- a/threatbus/stoppable_worker.py
+++ b/threatbus/stoppable_worker.py
@@ -4,7 +4,7 @@ from threading import Event, Thread
 class StoppableWorker(Thread):
     """
     A threading.Thread with a dedicated method, called _running(), for checking
-    if the thread should continue running. Invoking it's join() method changes
+    if the thread should continue running. Invoking it's stop() method changes
     the return value of _running(). Use this method as exit condition to model
     semi-infinite loops.
     """
@@ -13,12 +13,10 @@ class StoppableWorker(Thread):
         super(StoppableWorker, self).__init__()
         self._stop_event = Event()
 
-    def __stop(self):
+    def stop(self):
+        """Stops the current worker Thread"""
         self._stop_event.set()
 
     def _running(self):
+        """Private predicate to test if this worker should keep on running"""
         return not self._stop_event.is_set()
-
-    def join(self, *args, **kwargs):
-        self.__stop()
-        super(StoppableWorker, self).join(*args, **kwargs)

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -119,6 +119,7 @@ class ThreatBus(stoppable_worker.StoppableWorker):
         self.backbones.stop()
         self.apps.stop()
         self.logger.info("Stopping Threat Bus...")
+        super(ThreatBus, self).stop()
         self.join()
 
     def stop_signal(self, signal, frame):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR fixes a bug that was introduced with https://github.com/tenzir/threatbus/pull/61

This bug caused Threat Bus to terminate directly after startup in Python 3.7.3 and earlier. A detailed description of the issue can be found in this [Stackoverflow post](https://stackoverflow.com/questions/64917285/difference-in-python-thread-join-between-python-3-7-and-3-8).

###  :memo: Checklist

- [x] All user-facing changes have changelog entries. 
  *Not needed*: This fixes an *unreleased* bug and a Changelog entry for the desired behavior already exists.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit

Test this as follows:

- you need two Python installations, 3.7 <= Python <= 3.7.3 and Python >= 3.7.4
- two virtualenvs
- run `make dev-mode` in both envs
- craft a config that activates all plugins, see `config.yaml.example`
- start Threat Bus: `venv/bin/threatbus -c config.yaml` in each env (one at a time, else they try to use the same ports)
- wait a sec. it should keep running and not terminate on its own. send a few messages if you like.
- terminate it via `ctrl+c`
- it should gracefully stop all plugins, independent on the used Python version.
