### PR TITLE
Fix package entry point and imports

### DIFF
--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -7,7 +7,7 @@ import coloredlogs
 import confuse
 import json
 import logging
-from message_mapping import (
+from .message_mapping import (
     get_vast_intel_type,
     get_ioc,
     matcher_result_to_threatbus_sighting,

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -22,7 +22,9 @@ setup(
         "Topic :: System :: Distributed Computing",
     ],
     description="Connect the open source telemetry engine VAST with Threat Bus, the open source intelligence platform",
-    entry_points={"console_scripts": ["pyvast-threatbus=pyvast_threatbus:main"]},
+    entry_points={
+        "console_scripts": ["pyvast-threatbus=pyvast_threatbus.pyvast_threatbus:main"]
+    },
     include_package_data=True,
     install_requires=[
         "black>=19.10b",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Fix pyvast-threatbus packaging. There was a malformed entry point in it.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

In a virtual env run:
- `make dev-mode`
- `pyvast-threatbus -c apps/vast/config.yaml.example`
- -> should run the app without a startup error about malformed entrypoints