### PR TITLE
Remove workaround to convert ports to integers

### DIFF
--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -101,14 +101,6 @@ def query_result_to_threatbus_sighting(
         if not ts:
             return None
 
-        # TODO: remove the following logic that turns ports into integers.
-        for key, value in context.items():
-            if type(value) is str:
-                if value.endswith("/?"):
-                    context[key] = int(value[:-2])
-                elif value.endswith("/udp") or value.endswith("/tcp"):
-                    context[key] = int(value[:-4])
-
         return Sighting(
             dateutil_parser.parse(ts),
             intel.id,

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -30,9 +30,7 @@ class TestMessageMapping(unittest.TestCase):
         self.valid_intel = Intel(
             self.ts, self.id, self.valid_intel_data, self.operation
         )
-        self.valid_query_result = f'{{"timestamp": "{self.ts}", "flow_id": 1840147514011873, "pcap_cnt": 626, "src_ip": "{self.indicator[0]}", "src_port": "1193/?", "dest_ip": "65.54.95.64", "dest_port": "80/?", "proto": "TCP", "event_type": "http", "community_id": "1:AzSEWwmsqEKUX5qrReAHI3Rpizg=", "http.hostname": "download.windowsupdate.com", "http.url": "/v9/windowsupdate/a/selfupdate/WSUS3/x86/Other/wsus3setup.cab?0911180916", "http.http_port": null, "http.http_user_agent": "Windows-Update-Agent", "http.http_content_type": "application/octet-stream", "http.http_method": "HEAD", "http.http_refer": null, "http.protocol": "HTTP/1.1", "http.status": 200, "http.redirect": null, "http.length": 0, "tx_id": 0}}'
-        # TODO: the following is similar to the above, except for the ports - remove this, once VAST outputs ports as integers.
-        self.transformed_query_result = f'{{"timestamp": "{self.ts}", "flow_id": 1840147514011873, "pcap_cnt": 626, "src_ip": "{self.indicator[0]}", "src_port": 1193, "dest_ip": "65.54.95.64", "dest_port": 80, "proto": "TCP", "event_type": "http", "community_id": "1:AzSEWwmsqEKUX5qrReAHI3Rpizg=", "http.hostname": "download.windowsupdate.com", "http.url": "/v9/windowsupdate/a/selfupdate/WSUS3/x86/Other/wsus3setup.cab?0911180916", "http.http_port": null, "http.http_user_agent": "Windows-Update-Agent", "http.http_content_type": "application/octet-stream", "http.http_method": "HEAD", "http.http_refer": null, "http.protocol": "HTTP/1.1", "http.status": 200, "http.redirect": null, "http.length": 0, "tx_id": 0}}'
+        self.valid_query_result = f'{{"timestamp": "{self.ts}", "flow_id": 1840147514011873, "pcap_cnt": 626, "src_ip": "{self.indicator[0]}", "src_port": 1193, "dest_ip": "65.54.95.64", "dest_port": 80, "proto": "TCP", "event_type": "http", "community_id": "1:AzSEWwmsqEKUX5qrReAHI3Rpizg=", "http.hostname": "download.windowsupdate.com", "http.url": "/v9/windowsupdate/a/selfupdate/WSUS3/x86/Other/wsus3setup.cab?0911180916", "http.http_port": null, "http.http_user_agent": "Windows-Update-Agent", "http.http_content_type": "application/octet-stream", "http.http_method": "HEAD", "http.http_refer": null, "http.protocol": "HTTP/1.1", "http.status": 200, "http.redirect": null, "http.length": 0, "tx_id": 0}}'
         self.unflattened_query_result = f'{{"timestamp": "{self.ts}", "flow_id": 1840147514011873, "pcap_cnt": 626, "src_ip": "{self.indicator[0]}", "src_port": 1193, "dest_ip": "65.54.95.64", "dest_port": 80, "proto": "TCP", "event_type": "http", "community_id": "1:AzSEWwmsqEKUX5qrReAHI3Rpizg=", "http": {{"hostname": "download.windowsupdate.com", "url": "/v9/windowsupdate/a/selfupdate/WSUS3/x86/Other/wsus3setup.cab?0911180916", "http_port": null, "http_user_agent": "Windows-Update-Agent", "http_content_type": "application/octet-stream", "http_method": "HEAD", "http_refer": null, "protocol": "HTTP/1.1", "status": 200, "redirect": null, "length": 0}}, "tx_id": 0}}'
         self.valid_vast_sighting = f'{{"ts": "{self.ts}", "data_id": 8, "indicator_id": 5, "matcher": "threatbus-syeocdkfcy", "ioc": "{self.indicator[0]}", "reference": "threatbus__{self.id}"}}'
         self.invalid_intel_1 = {
@@ -202,7 +200,7 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(parsed_sighting.ioc, self.indicator)
 
         # TODO: use self.valid_query_result for comparison, once VAST outputs ports as integers
-        expected_context = json.loads(self.transformed_query_result)
+        expected_context = json.loads(self.valid_query_result)
         expected_context["source"] = "VAST"
         self.assertEqual(parsed_sighting.context, expected_context)
         self.assertEqual(parsed_sighting.intel, self.id)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

With the merge of https://github.com/tenzir/vast/pull/1187 VAST now exports ports a plain integers.
This PR removes a work-around that converted the former VAST-internal representation to ints.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run the modified unit-test suite.