### PR TITLE
Escape backslashes and quotes before querying VAST

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 `pyvast-threatbus` escapes backslashes and quotes in IoCs before it queries
+  VAST.
+  [#74](https://github.com/tenzir/threatbus/pull/74)
+
 - 🎁 `pyvast-threatbus` now uses asynchronous background tasks to query VAST
   concurrently. VAST queries were executed sequentially prior to this change.
   This boosts the performance by the factor of allowed concurrent background

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -62,6 +62,16 @@ def to_vast_ioc(intel: Intel):
     )
 
 
+def vast_escape_str(val: str):
+    """
+    Strings need to be passed to VAST in double quotes. In consequence, we must
+    escape double quotes before querying VAST.
+    """
+
+    val = val.replace("\\", "\\\\")
+    return val.replace('"', '\\"')
+
+
 def to_vast_query(intel: Intel):
     """
     Creates a VAST query from a Threat Bus Intel item.
@@ -73,9 +83,12 @@ def to_vast_query(intel: Intel):
     if not vast_type:
         return None
     indicator = get_ioc(intel)
+    if not indicator:
+        return None
+    indicator = vast_escape_str(str(indicator))
 
     if vast_type == "ip":
-        return str(indicator)
+        return indicator
     if vast_type == "url":
         return f'"{indicator}" in net.uri'
     if vast_type == "domain":

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -16,6 +16,7 @@ from .message_mapping import (
     to_vast_query,
     query_result_to_threatbus_sighting,
     matcher_result_to_threatbus_sighting,
+    vast_escape_str,
 )
 
 
@@ -225,3 +226,11 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(parsed_sighting.ioc, self.indicator)
         self.assertEqual(parsed_sighting.context, {"source": "VAST"})
         self.assertEqual(parsed_sighting.intel, self.id)
+
+    def test_vast_escape_str(self):
+        self.assertEqual(vast_escape_str('e"vil.com'), 'e\\"vil.com')
+        self.assertEqual(vast_escape_str('"evil.com"'), '\\"evil.com\\"')
+        self.assertEqual(vast_escape_str("e\\vil.com"), "e\\\\vil.com")
+        self.assertEqual(vast_escape_str('e\\"vil.com'), 'e\\\\\\"vil.com')
+        self.assertEqual(vast_escape_str('e\\\\""vil.com'), 'e\\\\\\\\\\"\\"vil.com')
+        self.assertEqual(vast_escape_str("e'vil.com"), "e'vil.com")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a bug where IoCs with quotes could lead to errors.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
 