### PR TITLE
Fix RabbitMQ user-defined queue parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 <!-- ## Unreleased -->
 
+##  [2020.11.30]
+
+- 🐞 The RabbitMQ backbone plugin ignored user-defined queue parameters, such as
+  `durable` or `lazy` queues. It now respects such parameters again.
+  [#76](https://github.com/tenzir/threatbus/pull/76)
+
 ##  [2020.11.26]
 
 - 🐞 The Zeek app did not perform an outbound connection to Threat Bus in
@@ -70,3 +76,4 @@ Every entry has a category for which we use the following visual abbreviations:
 
 [2020.10.29]: https://github.com/tenzir/threatbus/releases/tag/2020.10.29
 [2020.11.26]: https://github.com/tenzir/threatbus/releases/tag/2020.11.26
+[2020.11.30]: https://github.com/tenzir/threatbus/releases/tag/2020.11.30

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -31,5 +31,5 @@ setup(
     packages=["threatbus_rabbitmq"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.11.26",
+    version="2020.11.30",
 )

--- a/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/rabbitmq_consumer.py
+++ b/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/rabbitmq_consumer.py
@@ -265,6 +265,11 @@ class RabbitMQConsumer(threatbus.StoppableWorker):
         @param _frame Unused pika response
         @param userdata A tuple of exchange_name and queue_name. The exchange with the given name was created, hence this method is invoked. The queue name should be created.
         """
+        if type(userdata) is not tuple or len(userdata) != 2:
+            self.logger.warn(
+                f"Aborting with unexpected `userdata` after exchange was declared: {userdata}"
+            )
+            return
         cb = partial(self.on_queue_declare_ok, userdata=userdata)
         queue_kwargs = self.queue_kwargs.copy()
         queue_kwargs["callback"] = cb
@@ -276,6 +281,11 @@ class RabbitMQConsumer(threatbus.StoppableWorker):
         @param _frame Unused pika response
         @param userdata A tuple of exchange_name and queue_name. Both have been created, hence this method is invoked.
         """
+        if type(userdata) is not tuple or len(userdata) != 2:
+            self.logger.warn(
+                f"Aborting with unexpected `userdata` after queue was declared: {userdata}"
+            )
+            return
         cb = partial(self.on_queue_bind_ok, userdata=userdata[1])
         self._channel.queue_bind(exchange=userdata[0], queue=userdata[1], callback=cb)
 

--- a/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/rabbitmq_consumer.py
+++ b/plugins/backbones/threatbus_rabbitmq/threatbus_rabbitmq/rabbitmq_consumer.py
@@ -266,7 +266,9 @@ class RabbitMQConsumer(threatbus.StoppableWorker):
         @param userdata A tuple of exchange_name and queue_name. The exchange with the given name was created, hence this method is invoked. The queue name should be created.
         """
         cb = partial(self.on_queue_declare_ok, userdata=userdata)
-        self._channel.queue_declare(queue=userdata[1], callback=cb)
+        queue_kwargs = self.queue_kwargs.copy()
+        queue_kwargs["callback"] = cb
+        self._channel.queue_declare(queue=userdata[1], **queue_kwargs)
 
     def on_queue_declare_ok(self, _frame, userdata: Tuple[str, str]):
         """


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The rewrite in https://github.com/tenzir/threatbus/pull/61 introduced this bug. User-defined queue parameters were not passed to the RabbitMQ host.

This PR shall be released "out-of-band". Note: Our release workflow will trigger once we publish a new release. It will try to re-upload to PyPI and it will fail, because PyPI does not allow the re-use of existing versions but most versions haven't changed. So releasing without bumping all version numbers will color our CI red. It won't affect the correctness of the release, though.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.