### PR TITLE
Collect metrics with pyvast-threatbus

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
  ## Unreleased
 
+- ⚠️ `pyvast-threatbus` cannot be started with command line arguments anymore.
+  From now on, the application only supports one option, `-c`, to pass a config
+  file.
+
 - 🎁 `pyvast-threatbus` now uses the Threat Bus `logger` module. Users can
   configure logging the same way as in Threat Bus, via a `logging` section in
   the `config.yaml` file. The new configuration section and the `--loglevel`

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
  ## Unreleased
 
+- 🎁 `pyvast-threatbus` now supports basic metric collection. It stores metrics
+  in [influx line protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)
+  syntax in a configurable file on disk.
+
 - ⚠️ `pyvast-threatbus` cannot be started with command line arguments anymore.
   From now on, the application only supports one option, `-c`, to pass a config
   file.

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -15,15 +15,16 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🎁 `pyvast-threatbus` now supports basic metric collection. It stores metrics
   in [influx line protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)
   syntax in a configurable file on disk.
+  [#85](https://github.com/tenzir/threatbus/pull/85)
 
 - ⚠️ `pyvast-threatbus` cannot be started with command line arguments anymore.
   From now on, the application only supports one option, `-c`, to pass a config
   file.
+  [#85](https://github.com/tenzir/threatbus/pull/85)
 
 - 🎁 `pyvast-threatbus` now uses the Threat Bus `logger` module. Users can
   configure logging the same way as in Threat Bus, via a `logging` section in
-  the `config.yaml` file. The new configuration section and the `--loglevel`
-  option are mutually exclusive.
+  the `config.yaml` file.
   [#80](https://github.com/tenzir/threatbus/pull/80)
 
 ##  [2020.11.26]

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -5,6 +5,10 @@ logging:
   file_verbosity: DEBUG
   filename: pyvast-threatbus.log
 
+metrics:
+  interval: 10 # set to 0 to disable metrics
+  filename: metrics.log
+
 vast: "localhost:42000"
 vast_binary: vast
 threatbus: "localhost:13370"

--- a/apps/vast/pyvast_threatbus/metrics.py
+++ b/apps/vast/pyvast_threatbus/metrics.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from threading import Lock
+from sys import maxsize as max_integer
+
+
+class Metric:
+    """
+    A simple, thread-safe metric class with a name and a creation date. Can be
+    resetted to initial values by calling reset().
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        self.ts = datetime.now()
+        self.is_set = False  # indicator if the metric was touched
+        self._lock = Lock()
+
+    def reset(self):
+        """
+        Reset all values of the metric
+        """
+        self.ts = datetime.now()
+        with self._lock:
+            self.is_set = False
+
+
+class Summary(Metric):
+    """
+    A simple numeric summary metric
+    """
+
+    def __init__(self, name: str):
+        super(Summary, self).__init__(name)
+        self._count = 0  # invocation count
+        self._sum = 0  # sum of all values
+        self.min = max_integer  # minimum reported value
+        self.max = 0  # maximum reported value
+        self.avg = 0  # average of all reported values
+
+    def observe(self, value: int):
+        """
+        Store an observation to be part of this summary
+        """
+        with self._lock:
+            self.is_set = True
+            self._count += 1
+            self._sum += value
+            self.min = min(self.min, value)
+            self.max = max(self.max, value)
+            if self._count > 0:
+                self.avg = self._sum / self._count
+
+    def reset(self):
+        super(Summary, self).reset()
+        with self._lock:
+            self._count = 0
+            self._sum = 0
+            self.min = max_integer
+            self.max = 0
+            self.avg = 0
+
+
+class Gauge(Metric):
+    """
+    A simple numeric gauge that can go up and down
+    """
+
+    def __init__(self, name: str):
+        super(Gauge, self).__init__(name)
+        self.value = 0
+
+    def inc(self):
+        """
+        Increase the gauge value
+        """
+        with self._lock:
+            self.is_set = True
+            self.value += 1
+
+    def dec(self):
+        """
+        Decrease the gauge value
+        """
+        with self._lock:
+            self.is_set = True
+            self.value -= 1
+
+    def reset(self):
+        super(Gauge, self).reset()
+        with self._lock:
+            self.value = 0

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -77,24 +77,11 @@ def validate_config(config: confuse.Subview):
     config["transform_context"].add(None)
     config["sink"].add(None)
 
-    # logging
-    config["logging"].add({})
-    config["loglevel"].add("")
-    if config["loglevel"].get(str) and config["logging"].get(dict):
-        raise AssertionError(
-            "Found two conflicting config settings: 'loglevel' and 'logging'. Either configure 'logging' (verbose) or use 'loglevel' for console logging only."
-        )
-    if not config["loglevel"].get(str) and not config["logging"].get(dict):
-        raise AssertionError(
-            "No logging configured. Either specify '--loglevel' or configure the 'logging' section in the config.yaml file."
-        )
-
-    if config["logging"]:
-        if config["logging"]["console"].get(bool):
-            config["logging"]["console_verbosity"].get(str)
-        if config["logging"]["file"].get(bool):
-            config["logging"]["file_verbosity"].get(str)
-            config["logging"]["filename"].get(str)
+    if config["logging"]["console"].get(bool):
+        config["logging"]["console_verbosity"].get(str)
+    if config["logging"]["file"].get(bool):
+        config["logging"]["file_verbosity"].get(str)
+        config["logging"]["filename"].get(str)
 
 
 def cancel_async_tasks():
@@ -589,83 +576,6 @@ async def heartbeat(endpoint: str, p2p_topic: str, interval: int = 5):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", "-c", help="Path to a configuration file")
-    parser.add_argument(
-        "--vast",
-        "-v",
-        dest="vast",
-        default="localhost:42000",
-        help="Endpoint of a running VAST node",
-    )
-    parser.add_argument(
-        "--vast-binary",
-        "-b",
-        dest="vast_binary",
-        default="vast",
-        help="The vast command to use (either absolte path or a command available in $PATH)",
-    )
-    parser.add_argument(
-        "--threatbus",
-        "-t",
-        dest="threatbus",
-        default="localhost:13370",
-        help="Management endpoint of a VAST Threat Bus node",
-    )
-    parser.add_argument(
-        "--snapshot",
-        "-s",
-        dest="snapshot",
-        default=0,
-        type=int,
-        help="Request intelligence snapshot for past n days",
-    )
-    parser.add_argument(
-        "--loglevel",
-        "-l",
-        dest="loglevel",
-        type=str,
-        help="Loglevel to use for console logging. Note that you can specify file logging only via the config.yaml file.",
-    )
-    parser.add_argument(
-        "--retro-match",
-        dest="retro_match",
-        action="store_true",
-        help="Use plain vast queries instead of live-matcher",
-    )
-    parser.add_argument(
-        "--unflatten",
-        dest="unflatten",
-        action="store_true",
-        help="Only applicable when --retro-match is used. Unflatten the JSON results from VAST. The unflattening is applied immediately after retrieving the results from VAST, i.e., unflatten is applied before all further processing steps like --transform-context, --sink, or reporting back to Threat Bus.",
-    )
-    parser.add_argument(
-        "--retro-match-max-events",
-        dest="retro_match_max_events",
-        default=0,
-        type=int,
-        help="Use this options to fine-tune '--retro-match'. The app passes this option to VAST to at most return the configured number of sightings per IoC.",
-    )
-    parser.add_argument(
-        "--transform-context",
-        "-T",
-        dest="transform_context",
-        default=None,
-        help="Forward the context of each sighting (only the contents without the Threat Bus specific sighting structure) via a UNIX pipe. This option takes a command line string to use and invokes it as direct subprocess without shell / globbing support. Note: Treated as template string. Occurrences of '%%ioc' get replaced with the matched IoC.",
-    )
-    parser.add_argument(
-        "--sink",
-        "-S",
-        dest="sink",
-        default=None,
-        help="If sink is specified, sightings are not reported back to Threat Bus. Instead, the context of a sighting (only the contents without the Threat Bus specific sighting structure) is forwarded to the specified sink via a UNIX pipe. This option takes a command line string to use and invokes it as direct subprocess without shell / globbing support.",
-    )
-    parser.add_argument(
-        "--max-background-tasks",
-        "-U",
-        dest="max-background-tasks",
-        default=100,
-        type=int,
-        help="Controls the maximum number of concurrent background tasks for VAST queries. Default is 100.",
-    )
     args = parser.parse_args()
 
     # we need to use an underscore in the configuration name "pyvast_threatbus"

--- a/apps/vast/pyvast_threatbus/test_metrics.py
+++ b/apps/vast/pyvast_threatbus/test_metrics.py
@@ -1,0 +1,80 @@
+import unittest
+from sys import maxsize as max_integer
+from .metrics import Gauge, Summary
+
+
+class TestGauge(unittest.TestCase):
+    def setUp(self):
+        self.g = Gauge("test_gauge")
+
+    def test_init(self):
+        self.assertFalse(self.g.is_set)
+        self.assertEqual(self.g.value, 0)
+
+    def test_inc(self):
+        self.g.inc()
+        self.assertEqual(self.g.value, 1)
+        self.assertTrue(self.g.is_set)
+
+    def test_dec(self):
+        self.g.dec()
+        self.assertEqual(self.g.value, -1)
+        self.assertTrue(self.g.is_set)
+
+    def test_reset(self):
+        self.g.inc()
+        self.assertTrue(self.g.is_set)
+
+        self.g.reset()
+        self.assertFalse(self.g.is_set)
+        self.assertEqual(self.g.value, 0)
+
+
+class TestSummary(unittest.TestCase):
+    def setUp(self):
+        self.s = Summary("test_summary")
+
+    def test_init(self):
+        self.assertFalse(self.s.is_set)
+        self.assertEqual(self.s._sum, 0)
+        self.assertEqual(self.s._count, 0)
+        self.assertEqual(self.s.min, max_integer)
+        self.assertEqual(self.s.max, 0)
+        self.assertEqual(self.s.avg, 0)
+
+    def test_observe(self):
+        observation = 5
+        self.s.observe(5)
+        self.assertTrue(self.s.is_set)
+        self.assertEqual(self.s._sum, observation)
+        self.assertEqual(self.s._count, 1)  # invoked once
+        self.assertEqual(self.s.min, observation)
+        self.assertEqual(self.s.max, observation)
+        self.assertEqual(self.s.avg, observation)
+
+    def test_observe_multiple(self):
+        self.s.observe(1)
+        self.s.observe(2)
+        self.s.observe(3)
+        self.s.observe(4)
+        self.s.observe(5)
+        self.s.observe(10)
+
+        self.assertTrue(self.s.is_set)
+        self.assertEqual(self.s._sum, 25)  # 1+2+3+4+5+10
+        self.assertEqual(self.s._count, 6)  # invoked 6 times
+        self.assertEqual(self.s.min, 1)
+        self.assertEqual(self.s.max, 10)
+        self.assertEqual(self.s.avg, 25 / 6)
+
+    def test_reset(self):
+        self.s.observe(5)
+        self.assertTrue(self.s.is_set)
+
+        self.s.reset()
+        self.assertFalse(self.s.is_set)
+        self.assertEqual(self.s._sum, 0)
+        self.assertEqual(self.s._count, 0)
+        self.assertEqual(self.s.min, max_integer)
+        self.assertEqual(self.s.max, 0)
+        self.assertEqual(self.s.avg, 0)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Collect `min`, `max`, and `avg` metrics for `pyvast-threatbus`. Store to file in configurable interval in [influx line protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)
###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.
Run the unit-tests.

You can verify locally that metrics are collected by configuring the `metrics` section in your `config.yaml` and sending IoCs to `pyvast-threatbus`.
