### PR TITLE
Add sighting with misp testutil

### DIFF
--- a/tests/utils/misp-ioc-sender/README.md
+++ b/tests/utils/misp-ioc-sender/README.md
@@ -9,6 +9,7 @@ The script works as follows:
 - Create the Event if it doesn't exist.
 - Check the Attributes of the Event and either create a new Attribute or toggle
   the `'to_ids'` flag if the Attribute already exists.
+- If configured, additionally report a sighting for the attribute.
 
 Attributes created by this script always have the `"DOMAIN"` type. Attribute
 values contain the current day of the year and are always formatted like this:

--- a/tests/utils/misp-ioc-sender/config.yaml.example
+++ b/tests/utils/misp-ioc-sender/config.yaml.example
@@ -11,3 +11,4 @@ misp:
   key: <MISP_KEY>
 
 event-uuid: 5f7b2277-1ebc-4101-9152-032ac0a82fae  # this UUID is either retrieved or created.
+report_sighting: true


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Additionally add sightings in MISP testutil.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

file-by-file