### PR TITLE
Warn for configured but uninstalled plugins

### DIFF
--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -183,6 +183,12 @@ def start(config: confuse.Subview):
             f"Disabling installed, but unconfigured backbones '{unwanted_backbones}'"
         )
         backbones.unregister(name=unwanted_backbones)
+    for unconfigured_app in (configured_apps - installed_apps).union(
+        configured_backbones - installed_backbones
+    ):
+        tb_logger.warn(
+            f"Found configuration for '{unconfigured_app}' but no plugin with that name is installed."
+        )
 
     bus_thread = ThreatBus(backbones.hook, apps.hook, tb_logger, config)
     signal.signal(signal.SIGINT, bus_thread.stop_signal)

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -187,7 +187,7 @@ def start(config: confuse.Subview):
         configured_backbones - installed_backbones
     ):
         tb_logger.warn(
-            f"Found configuration for '{unconfigured_app}' but no plugin with that name is installed."
+            f"Found configuration for '{unconfigured_app}' but no corresponding plugin is installed."
         )
 
     bus_thread = ThreatBus(backbones.hook, apps.hook, tb_logger, config)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Threat Bus now warns when it finds configuration blocks for plugins that are not installed.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

file-by-file.