### PR TITLE
fix typo in logger call

### DIFF
--- a/tests/utils/misp-ioc-sender/misp-ioc-sender.py
+++ b/tests/utils/misp-ioc-sender/misp-ioc-sender.py
@@ -66,7 +66,7 @@ def connect_misp(host: str, key: str, ssl: bool):
     try:
         return pymisp.ExpandedPyMISP(url=host, key=key, ssl=ssl)
     except Exception:
-        logger.ciritcal(f"Cannot connect to MISP at '{host}', using SSL '{ssl}'")
+        logger.critical(f"Cannot connect to MISP at '{host}', using SSL '{ssl}'")
 
 
 def get_or_create_event(misp: pymisp.api.PyMISP, event_uuid: str):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

* Fix a typo in `tests/utils/misp-ioc-sender/misp-ioc-sender.py` logging an error connecting to MISP instance.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try to connect to an unreachable MISP instance and confirm correct error message output.