### PR TITLE
Delete assets before uploading new ones

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -106,14 +106,25 @@ jobs:
         ASSET="$ARCHIVE.gz"
         echo "::set-output name=name::$NAME"
         echo "::set-output name=asset::$ASSET"
+    # This step ensures that assets from previous runs are cleaned up to avoid
+    # failure of the next step (asset upload)
+    - name: Delete existing Release Assets
+      if: github.event.action == 'published'
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        fail-if-no-assets: false # don't fail if no previous assets exist
+        fail-if-no-release: true # only delete assets when `tag` refers to a release
+        assets: ${{ steps.create_release.outputs.asset }}
     - name: Publish to GitHub
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.create_release.outputs.asset}}
-        asset_name: ${{ steps.create_release.outputs.name}}
+        asset_path: ${{ steps.create_release.outputs.asset }}
+        asset_name: ${{ steps.create_release.outputs.name }}
         asset_content_type: application/gzip
     - name: Publish to PyPI
       run: |


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

https://github.com/mknejp/delete-release-assets

Proposal: delete release assets if they exist before attempting to upload new assets. This is to avoid errors when uploading assets that already exist.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
See this run in a repository I created to test these two actions in isolation: https://github.com/0snap/release-action-test/runs/1816583406?check_suite_focus=true