### PR TITLE
Enable both live- and retro-matching

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ Users now can use both, retro-matching and live-matching with VAST
+  simultaneously for any given IoC. On the flip side, there is no longer a
+  default mode of operation. To use live-matching, users now must specifically
+  configure it via setting `live_match: true` in their `config.yaml` file.
+  [#95](https://github.com/tenzir/threatbus/pull/95)
+
 - ⚠️ `pyvast-threatbus` drops support to unflatten JSON that it receives from
   `vast export` because VAST can now return unflattened JSON
   [by default](https://github.com/tenzir/vast/pull/1257).

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -13,6 +13,8 @@ vast: "localhost:42000"
 vast_binary: vast
 threatbus: "localhost:13370"
 snapshot: 30
+# live-matching requires you to install the VAST matcher plugin
+live_match: false
 retro_match: true
 retro_match_max_events: 0
 unflatten: true

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -439,7 +439,7 @@ async def live_match_vast(
     matcher_name = "threatbus-" + "".join(random.choice(letters) for i in range(10))
     proc = await vast.matcher().start(name=matcher_name).exec()
     # returncode is None as long as the process did not terminate yet
-    while proc.returncode == None:
+    while proc.returncode is None:
         data = await proc.stdout.readline()
         if not data:
             if not await vast.test_connection():

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -80,7 +80,11 @@ def validate_config(config: confuse.Subview):
     config["vast_binary"].get(str)
     config["threatbus"].get(str)
     config["snapshot"].get(int)
-    config["retro_match"].get(bool)
+    live_match = config["live_match"].get(bool)
+    retro_match = config["retro_match"].get(bool)
+    assert (
+        live_match or retro_match
+    ), "please enable at least one kind of matching (live_match and/or retro_match)"
     config["retro_match_max_events"].get(int)
     config["max_background_tasks"].get(int)
 
@@ -116,6 +120,7 @@ async def start(
     vast_endpoint: str,
     zmq_endpoint: str,
     snapshot: int,
+    live_match: bool,
     retro_match: bool,
     retro_match_max_events: int,
     max_open_files: int,
@@ -132,7 +137,8 @@ async def start(
     @param vast_endpoint The endpoint of a running VAST node ('host:port')
     @param zmq_endpoint The ZMQ management endpoint of Threat Bus ('host:port')
     @param snapshot An integer value to request n days of past intel items
-    @param retro_match Boolean flag to use retro-matching over live-matching
+    @param live_match Boolean flag to enable live-matching
+    @param retro_match Boolean flag to enable retro-matching
     @param retro_match_max_events Max amount of retro match results
     @param max_open_files The maximum number of concurrent background tasks for VAST queries.
     @param merics_interval The interval in seconds to bucketize metrics
@@ -665,6 +671,7 @@ def main():
                     config["vast"].get(),
                     config["threatbus"].get(),
                     config["snapshot"].get(),
+                    config["live_match"].get(),
                     config["retro_match"].get(),
                     config["retro_match_max_events"].get(),
                     config["max_background_tasks"].get(),


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Allow the user to configure using both, live-matching and retro-matching at the same time for one given IoC.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

You can test this interactively as follows:
- Annotate a vast-schema with `#ioc` e.g., the `hostname` field of suricata logs
- Start VAST-Pro 
- Start Threat Bus
- Start `pyvast-threatbus`, change the config so both `live_match` and `retro_match` are set to `true`
- Ingest suricata data into vast, manipulate a hostname
- Inject IoCs into Threat Bus (either via a local MISP instance or by directly injecting into the backbone, e.g., RabbitMQ), use the same hostname you ingested via the logs. That should trigger two things:
  - a retro-match
  - the IoC is made known to the vast matcher
- ingest the same manipulated log again
  - that should trigger a live-match


Note: I did the above on my machine and can confirm this works with an old version of VAST Pro (`2020.08.28-263-ga7b5ed3b`) on Arch Linux, using Python 3.8.6.