### PR TITLE
Allow unlimited VAST retro-queries

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,8 +12,8 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🐞 Users can now run unlimited retro-queries against VAST by setting the
-  `retro_match_max_events` parameter to `0`.
+- 🐞 Users can now run retro-queries with an unbounded number of results against
+  VAST by setting the `retro_match_max_events` parameter to `0`.
   [#98](https://github.com/tenzir/threatbus/pull/98)
 
 - ⚠️ Users now can use both, retro-matching and live-matching with VAST

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Users can now run unlimited retro-queries against VAST by setting the
+  `retro_match_max_events` parameter to `0`.
+  [#98](https://github.com/tenzir/threatbus/pull/98)
+
 - ⚠️ Users now can use both, retro-matching and live-matching with VAST
   simultaneously for any given IoC. On the flip side, there is no longer a
   default mode of operation. To use live-matching, users now must specifically

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -16,7 +16,7 @@ snapshot: 30
 # live-matching requires you to install the VAST matcher plugin
 live_match: false
 retro_match: true
-retro_match_max_events: 0 # set to 0 for unlimited queries
+retro_match_max_events: 0 # set to 0 for unlimited results
 unflatten: true
 # optional. remove the field if you don't want to transform sighting context
 transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -16,7 +16,7 @@ snapshot: 30
 # live-matching requires you to install the VAST matcher plugin
 live_match: false
 retro_match: true
-retro_match_max_events: 0
+retro_match_max_events: 0 # set to 0 for unlimited queries
 unflatten: true
 # optional. remove the field if you don't want to transform sighting context
 transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -313,7 +313,10 @@ async def retro_match_vast(
     global logger, max_open_tasks
     async with max_open_tasks:
         vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-        proc = await vast.export(max_events=retro_match_max_events).json(query).exec()
+        kwargs = {}
+        if retro_match_max_events > 0:
+            kwargs["max_events"] = retro_match_max_events
+        proc = await vast.export(**kwargs).json(query).exec()
         reported = 0
         while not proc.stdout.at_eof():
             line = (await proc.stdout.readline()).decode().rstrip()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We used to always pass the `--max-events=` parameter to VAST, regardless of the value of the parameter. Setting it to 0 led to zero results.

This PR enables `pyvast-threatbus to run unlimited queries by setting the `retro_match_max_events` parameter to `0`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit