### PR TITLE
Use optional dependencies for different MISP integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Every entry has a category for which we use the following visual abbreviations:
 ## Unreleased
 
 - 🎁 Feature
+  The MISP plugin now uses [extra dependencies](https://www.python.org/dev/peps/pep-0508/#extras).
+  Users can now chose the wanted dependencies during installation by running
+  `pip install threatbus-misp[zmq]` to install the ZeroMQ dependency, or
+  `pip install threatbus-misp[kafka]` to install the Kafka dependency. The
+  plugin throws a fatal error if none of these dependencies is installed and
+  exits immediately.
+  [#99](https://github.com/tenzir/threatbus/pull/99)
+
+- 🎁 Feature
   The RabbitMQ backbone plugin, the In-memory backbone plugins, and the Zmq-app
   plugin now support the
   [STIX-2 (version 2.1)](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)

--- a/plugins/apps/threatbus_misp/Makefile
+++ b/plugins/apps/threatbus_misp/Makefile
@@ -30,8 +30,8 @@ dist:
 
 .PHONY: install
 install:
-	pip install .
+	pip install .[zmq]
 
 .PHONY: dev-mode
 dev-mode:
-	pip install --editable .
+	pip install --editable .[zmq]

--- a/plugins/apps/threatbus_misp/README.md
+++ b/plugins/apps/threatbus_misp/README.md
@@ -9,32 +9,55 @@ Threat Bus MISP Plugin
 
 </h4>
 
-A Threat Bus plugin that enables communication to [MISP](https://www.misp-project.org/).
+A Threat Bus plugin that enables communication with [MISP](https://www.misp-project.org/).
 
 The plugin goes against the pub/sub architecture of Threat Bus (for now),
-because the plugin subscribes a listener to ZeroMQ / Kafka, rather than having
-MISP subscribe itself to Threat Bus. That will be addressed with a MISP module
-in the near future.
+because it actively binds to a single MISP instance to receive attribute
+(IoC) updates, and report back sightings via the REST API. Following the strict
+pub/sub architecture of Threat Bus, it *should be the other way
+around*, with MISP binding to Threat Bus. This will eventually be resolved by a
+MISP module.
+
+For now, the plugin supports two ways to retrieve attribute (IoC) updates from
+MISP - either via ZeroMQ or via Kafka. Basically, the plugin makes itself a
+subscriber to MISP events.
 
 ## Installation
 
+Users can specify *optional dependencies* during installation. The plugin uses
+either ZeroMQ or Kafka to get IoC updates from MISP. As we don't want to burden
+the user to install unused dependencies, both options are available as follows:
+
+
 ```sh
-pip install threatbus-misp
+pip install threatbus-misp[zmq]
+pip install threatbus-misp[kafka]
 ```
 
-#### Prerequisites
+If neither of these dependencies is installed (i.e., you installed
+`threatbus-misp` without the `[...]` suffix for optional deps), the plugin throws
+an error and exits immediately.
 
-*Install Kafka on the Threat Bus host*
+### Kafka Prerequisites
 
-The plugin enables communication either via ZeroMQ or Kafka. When using Kafka,
-you have to install `librdkafka` for the host system that is running
-`threatbus`. See also the [prerequisites](https://github.com/confluentinc/confluent-kafka-python#prerequisites)
-section of the `confluent-kafka` python client.
+When you decide to use Kafka to receive IoC updates from MISP, you first need to
+install Kafka on the Threat Bus host. This plugin uses the
+[confluent-kafka](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/index.html)
+Python package which requires `librdkafka`. See also the
+[prerequisites](https://github.com/confluentinc/confluent-kafka-python#prerequisites)
+section of the `confluent-kafka` Python client for details about setting it up
+for your distribution.
+
+Once installed, go ahead and install the Kafka version of this plugin:
+
+```
+pip install threatbus-misp[kafka]
+```
 
 ## Configuration
 
-The plugin can either use ZeroMQ or Kafka to retrieve intelligence items from
-MISP. It uses the MISP REST api to report back sightings of indicators.
+The plugin uses the MISP REST API to report back sightings of IoCs. You need to
+specify a MISP API key for it to work.
 
 ZeroMQ and Kafka are mutually exclusive, such that Threat Bus does not receive
 all attribute updates twice. See below for an example configuration.
@@ -79,7 +102,7 @@ plugins:
 ...
 ```
 
-### Filter
+### IoC Filter
 
 The plugin can be configured with a list of filters. Every filter describes a
 whitelist for MISP attributes (IoCs). The MISP plugin will only forward IoCs to
@@ -219,7 +242,7 @@ misp-server:
 make deploy
 ```
 
-*Enable the Kafka plugin in the MISP webview*
+*Enable the Kafka plugin in the MISP web-view*
 
 - Visit https://localhost:80
 - login with your configured credentials
@@ -250,7 +273,7 @@ service apache2 restart
 exit # leave the Docker container shell
 ```
 
-*Enable the ZMQ plugin in the MISP webview*
+*Enable the ZMQ plugin in the MISP web-view*
 
 - Visit https://localhost:80
 - login with your configured credentials

--- a/plugins/apps/threatbus_misp/README.md
+++ b/plugins/apps/threatbus_misp/README.md
@@ -38,6 +38,10 @@ If neither of these dependencies is installed (i.e., you installed
 `threatbus-misp` without the `[...]` suffix for optional deps), the plugin throws
 an error and exits immediately.
 
+**Depending on your setup, you might want to use quotes to avoid shell expansion
+when using `[...]`**. For example, you can do `pip install ".[zmq]"` for local
+development.
+
 ### Kafka Prerequisites
 
 When you decide to use Kafka to receive IoC updates from MISP, you first need to

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with MISP.",
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
-        "threatbus>=2020.12.16",
+        "threatbus >= 2020.12.16, < 2021.2.24",
         "pymisp >= 2.4.120",
     ],
     extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -27,10 +27,9 @@ setup(
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
         "threatbus>=2020.12.16",
-        "pymisp >= 2.4.120, <= 2.4.134",
-        "pyzmq>=18.1.1",
-        "confluent-kafka>=1.3.0",
+        "pymisp >= 2.4.120",
     ],
+    extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},
     keywords=[
         "MISP",
         "zeromq",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Attributes can either be exported from MISP via ZeroMQ or via Kafka. The MISP plugin supports both, but also used to force the user to have both dependencies installed.

This PR eliminates the need to install both dependencies by using [extra dependencies (PEP 508)](https://www.python.org/dev/peps/pep-0508/#extras). This breaks how the plugin is installed:

```
pip install threatbus-misp[zmq]
pip install threatbus-misp[kafka]
```

A plain `pip install threatbus-misp` without specifying the extras option works, but the plugin will throw a critical error during config validation and terminate right after.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.