### PR TITLE
Prepare February Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental feature
 - 🐞 Bugfix
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [2021.02.24]
 
 - 🎁 Feature
   The MISP plugin now uses [extra dependencies](https://www.python.org/dev/peps/pep-0508/#extras).
@@ -117,3 +119,4 @@ Every entry has a category for which we use the following visual abbreviations:
 [2020.11.26]: https://github.com/tenzir/threatbus/releases/tag/2020.11.26
 [2020.11.30]: https://github.com/tenzir/threatbus/releases/tag/2020.11.30
 [2020.12.16]: https://github.com/tenzir/threatbus/releases/tag/2020.12.16
+[2021.02.24]: https://github.com/tenzir/threatbus/releases/tag/2021.02.24

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ install:
 .PHONY: dev-mode
 dev-mode:
 	pip install --editable .
-	$(MAKE) -C plugins/apps/threatbus_zeek dev-mode
-	$(MAKE) -C plugins/apps/threatbus_misp dev-mode
 	$(MAKE) -C plugins/apps/threatbus_zmq_app dev-mode
-	$(MAKE) -C plugins/apps/threatbus_cif3 dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_inmem dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_rabbitmq dev-mode
-	$(MAKE) -C apps/vast dev-mode
+	# $(MAKE) -C plugins/apps/threatbus_zeek dev-mode
+	# $(MAKE) -C plugins/apps/threatbus_misp dev-mode
+	# $(MAKE) -C plugins/apps/threatbus_cif3 dev-mode
+	# $(MAKE) -C apps/vast dev-mode

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ unit-tests:
 	$(MAKE) -C plugins/backbones/threatbus_inmem unit-tests
 	$(MAKE) -C plugins/backbones/threatbus_rabbitmq unit-tests
 	$(MAKE) -C plugins/apps/threatbus_zmq_app unit-tests
+  # Threat Bus is currently being migrated to use STIX-2 as internal format.
+  # For the time being, all un-migrated plugins cannot be not tested against the
+  # current master
 	#$(MAKE) -C plugins/apps/threatbus_zeek unit-tests
 	#$(MAKE) -C plugins/apps/threatbus_misp unit-tests
 	#$(MAKE) -C plugins/apps/threatbus_cif3 unit-tests
@@ -88,6 +91,9 @@ dev-mode:
 	$(MAKE) -C plugins/apps/threatbus_zmq_app dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_inmem dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_rabbitmq dev-mode
+  # Threat Bus is currently being migrated to use STIX-2 as internal format.
+  # For the time being, all un-migrated plugins cannot be run in conjunction
+  # with current master
 	# $(MAKE) -C plugins/apps/threatbus_zeek dev-mode
 	# $(MAKE) -C plugins/apps/threatbus_misp dev-mode
 	# $(MAKE) -C plugins/apps/threatbus_cif3 dev-mode

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [2021.02.24]
 
 - 🐞 Users can now run retro-queries with an unbounded number of results against
   VAST by setting the `retro_match_max_events` parameter to `0`.
@@ -64,3 +66,4 @@ Every entry has a category for which we use the following visual abbreviations:
 
 [2020.11.26]: https://github.com/tenzir/threatbus/releases/tag/2020.11.26
 [2020.12.16]: https://github.com/tenzir/threatbus/releases/tag/2020.12.16
+[2021.02.24]: https://github.com/tenzir/threatbus/releases/tag/2021.02.24

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -32,7 +32,8 @@ setup(
         "confuse",
         "pyzmq>=19",
         "pyvast>=2020.10.29",
-        "threatbus>=2020.12.16",
+        "threatbus >= 2020.12.16, < 2021.2.24",
+        "threatbus-zmq-app >= 2020.12.16, < 2021.2.24",
     ],
     keywords=[
         "open source",
@@ -51,5 +52,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -25,7 +25,10 @@ setup(
     ],
     description="A plugin to enable indicators to be submitted to CIFv3 in real-time",
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
-    install_requires=["threatbus>=2020.12.16", "cifsdk>3.0.0rc4,<4.0"],
+    install_requires=[
+        "threatbus >= 2020.12.16, < 2021.2.24",
+        "cifsdk > 3.0.0rc4, < 4.0",
+    ],
     keywords=[
         "cif",
         "cifv3",
@@ -45,5 +48,5 @@ setup(
     packages=["threatbus_cif3"],
     python_requires=">=3.6",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -48,5 +48,5 @@ setup(
     packages=["threatbus_misp"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with Zeek network monitor.",
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
     install_requires=[
-        "threatbus>=2020.12.16",
+        "threatbus >= 2020.12.16, < 2021.2.24",
     ],
     keywords=[
         "Zeek",
@@ -49,5 +49,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/apps/threatbus_zmq_app/README.md
+++ b/plugins/apps/threatbus_zmq_app/README.md
@@ -16,16 +16,16 @@ communicate via [ZeroMQ].
 ## Installation
 
 ```sh
-pip install threatbus-vast
+pip install threatbus-zmq-app
 ```
 
 ## Configuration
 
-The plugin uses ZeroMQ to communicate with applications, like the
-[VAST bridge](https://github.com/tenzir/threatbus/tree/master/apps/vast). The
-plugin serves three ZeroMQ endpoints to connect with. One endpoint for managing
-subscriptions (and thus snapshot requests). The other two endpoints exist
-for pub-sub operations.
+The plugin uses ZeroMQ to communicate with applications, like
+[pyvast-threatbus](https://github.com/tenzir/threatbus/tree/master/apps/vast).
+The plugin serves three ZeroMQ endpoints to connect with. One endpoint for
+managing subscriptions (and thus snapshot requests). The other two endpoints
+exist for pub-sub operations.
 
 ```yaml
 ...
@@ -160,7 +160,7 @@ pattern. Threat Bus answers immediately to each heartbeat request with either a
   }
   ```
 
-An `error` response indicates that either Threat Bus has internal erros or that
+An `error` response indicates that either Threat Bus has internal errors or that
 it lost track of the app's subscription. Note: This only happens when Threat Bus
 is restarted. Apps can then use that information to re-subscribe.
 

--- a/plugins/apps/threatbus_zmq_app/setup.py
+++ b/plugins/apps/threatbus_zmq_app/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyzmq>=19",
         "python-dateutil>=2.8.1",
         "stix2>=2.1",
-        "threatbus>=2020.12.16",
+        "threatbus>=2021.2.24",
     ],
     keywords=[
         "zeromq",
@@ -47,5 +47,5 @@ setup(
     packages=["threatbus_zmq_app"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/backbones/file_benchmark/setup.py
+++ b/plugins/backbones/file_benchmark/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     description="A benchmark backbone for threatbus, that reads a file and provisions its contents.",
     entry_points={"threatbus.backbone": ["file_benchmark = file_benchmark.plugin"]},
-    install_requires=["stix2>=2.1", "threatbus>=2020.12.16"],
+    install_requires=["stix2>=2.1", "threatbus>=2021.2.24"],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
     long_description=long_description,
@@ -31,5 +31,5 @@ setup(
     packages=["file_benchmark"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     description="A simplistic in-memory backbone for threatbus.",
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
-    install_requires=["stix2>=2.1", "threatbus>=2020.12.16"],
+    install_requires=["stix2>=2.1", "threatbus>=2021.2.24"],
     keywords=[
         "message broker",
         "threatbus",
@@ -38,5 +38,5 @@ setup(
     packages=["threatbus_inmem"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -26,7 +26,7 @@ setup(
         "pika>=1.1.0",
         "retry",
         "stix2>=2.1",
-        "threatbus>=2020.12.16",
+        "threatbus>=2021.2.24",
     ],
     keywords=[
         "message broker",
@@ -46,5 +46,5 @@ setup(
     packages=["threatbus_rabbitmq"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2020.12.16",
+    version="2021.02.24",
 )


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Pin versions for different plugins to keep compatibility with older versions installed on PyPI
- Disable `dev-mode` Make target for un-migrated plugins (resp. STIX-2)

This PR is branched off https://github.com/tenzir/threatbus/pull/99 - that has to be merged first.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.