### PR TITLE
Disable unmigrated plugins w/o STIX-2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ COPY README.md .
 COPY threatbus threatbus
 COPY plugins plugins
 RUN python3 -m pip install . && \
-  python3 -m pip install plugins/apps/threatbus_misp && \
-  python3 -m pip install plugins/apps/threatbus_zeek && \
+  #python3 -m pip install plugins/apps/threatbus_misp && \
+  #python3 -m pip install plugins/apps/threatbus_zeek && \
+  #python3 -m pip install plugins/apps/threatbus_cif3 && \
   python3 -m pip install plugins/apps/threatbus_zmq_app && \
-  python3 -m pip install plugins/apps/threatbus_cif3 && \
   python3 -m pip install plugins/backbones/threatbus_inmem && \
   python3 -m pip install plugins/backbones/threatbus_rabbitmq
 COPY config* ./


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Disable all plugins that do not yet support STIX-2 in the Dockerfile

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.

If you like, do a quick `docker build .`.