### PR TITLE
Rewrite MISP plugin to convert to/from STIX-2 Indicators and Sightings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,28 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental feature
 - 🐞 Bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 The MISP plugin now supports the
+  [STIX-2 (version 2.1)](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)
+  standard for
+  [Indicators](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_muftrcpnf89v)
+  and [Sightings](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_a795guqsap3r).
+  The plugin converts MISP attributes to valid STIX-2 Indicators on best-effort
+  basis before publishing them on Threat Bus topics. Likewise, the plugin
+  converts STIX-2 sightings to MISP sightings before sending them the MISP.
+  [#102](https://github.com/tenzir/threatbus/pull/102)
+
+- 🐞 We fixed a bug in the JSON (de-)serialization logic for `SnapshotEnvelope`s
+  and `SnapshotRequest`s that lead to a malformed `type` field in the JSON
+  representations of both types.
+  [#102](https://github.com/tenzir/threatbus/pull/102)
+
 
 ## [2021.02.24]
 
-- 🎁 Feature
-  The MISP plugin now uses [extra dependencies](https://www.python.org/dev/peps/pep-0508/#extras).
+- 🎁 The MISP plugin now uses
+  [extra dependencies](https://www.python.org/dev/peps/pep-0508/#extras).
   Users can now chose the wanted dependencies during installation by running
   `pip install threatbus-misp[zmq]` to install the ZeroMQ dependency, or
   `pip install threatbus-misp[kafka]` to install the Kafka dependency. The
@@ -23,9 +39,8 @@ Every entry has a category for which we use the following visual abbreviations:
   exits immediately.
   [#99](https://github.com/tenzir/threatbus/pull/99)
 
-- 🎁 Feature
-  The RabbitMQ backbone plugin, the In-memory backbone plugins, and the Zmq-app
-  plugin now support the
+- 🎁 The RabbitMQ backbone plugin, the In-memory backbone plugins, and the
+  Zmq-app plugin now support the
   [STIX-2 (version 2.1)](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)
   standard for
   [Indicators](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_muftrcpnf89v)

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ unit-tests:
 	$(MAKE) -C plugins/backbones/threatbus_inmem unit-tests
 	$(MAKE) -C plugins/backbones/threatbus_rabbitmq unit-tests
 	$(MAKE) -C plugins/apps/threatbus_zmq_app unit-tests
+	$(MAKE) -C plugins/apps/threatbus_misp unit-tests
   # Threat Bus is currently being migrated to use STIX-2 as internal format.
   # For the time being, all un-migrated plugins cannot be not tested against the
   # current master
 	#$(MAKE) -C plugins/apps/threatbus_zeek unit-tests
-	#$(MAKE) -C plugins/apps/threatbus_misp unit-tests
 	#$(MAKE) -C plugins/apps/threatbus_cif3 unit-tests
 	#$(MAKE) -C apps/vast unit-tests
 
@@ -34,10 +34,11 @@ integration-tests:
 	-docker kill rabbit-int > /dev/null 2>&1
 	docker pull rabbitmq$(:)3 > /dev/null 2>&1
 	docker run -d --rm --hostname=test-rabbit --name=rabbit-int -p 35672$(:)5672 rabbitmq$(:)3 > /dev/null 2>&1
-	-python -m unittest tests/integration/test_message_roundtrips.py
-	-python -m unittest tests/integration/test_zeek_app.py
-	-python -m unittest tests/integration/test_rabbitmq.py
+	-python -m unittest tests/integration/test_misp_inmem.py
 	-python -m unittest tests/integration/test_zmq_app_management.py
+	# -python -m unittest tests/integration/test_rabbitmq.py
+	# -python -m unittest tests/integration/test_zeek_app.py
+	# -python -m unittest tests/integration/test_message_roundtrips.py
 	-${RM} {broker,intel,reporter,weird}.log
 	docker kill rabbit-int > /dev/null 2>&1
 
@@ -91,10 +92,10 @@ dev-mode:
 	$(MAKE) -C plugins/apps/threatbus_zmq_app dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_inmem dev-mode
 	$(MAKE) -C plugins/backbones/threatbus_rabbitmq dev-mode
+	$(MAKE) -C plugins/apps/threatbus_misp dev-mode
   # Threat Bus is currently being migrated to use STIX-2 as internal format.
   # For the time being, all un-migrated plugins cannot be run in conjunction
   # with current master
 	# $(MAKE) -C plugins/apps/threatbus_zeek dev-mode
-	# $(MAKE) -C plugins/apps/threatbus_misp dev-mode
 	# $(MAKE) -C plugins/apps/threatbus_cif3 dev-mode
 	# $(MAKE) -C apps/vast dev-mode

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -26,8 +26,9 @@ setup(
     description="A plugin to enable threatbus communication with MISP.",
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
-        "threatbus >= 2020.12.16, < 2021.2.24",
         "pymisp >= 2.4.120",
+        "stix2 >= 2.1",
+        "threatbus >= 2021.2.24",
     ],
     extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},
     keywords=[

--- a/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
@@ -1,41 +1,51 @@
 from datetime import datetime
 import json
-import unittest
-
-from threatbus.data import Intel, IntelData, IntelType, Operation, Sighting
+from pymisp import MISPSighting
+from stix2 import Indicator, Sighting
+from threatbus.data import Operation, Update
 from threatbus_misp.message_mapping import (
-    map_to_internal,
-    map_to_misp,
+    attribute_to_stix2_indicator,
+    stix2_sighting_to_misp,
     is_whitelisted,
     get_tags,
 )
+import unittest
 
 
 class TestMessageMapping(unittest.TestCase):
     def setUp(self):
         self.raw_ts = 1579104545
         self.ts = datetime.fromtimestamp(self.raw_ts)
-        self.id = "15"
-        self.indicator = "example.com"
-        self.expected_intel_type = IntelType.DOMAIN
+        self.domain_ioc = "example.com"
+        self.ip_ioc = "example.com"
+        self.pattern = f"[domain-name:value = '{self.domain_ioc}'] AND [ipv4-addr:value = '{self.ip_ioc}']"
+        self.attr_uuid = "5e1f2787-fcfc-4718-a58a-00b4c0a82f06"
+        self.indicator_id = f"indicator--{self.attr_uuid}"
+        self.indicator = Indicator(
+            id=self.indicator_id,
+            created=self.ts,
+            pattern_type="stix",
+            pattern=self.pattern,
+        )
+        self.sighting = Sighting(created=self.ts, sighting_of_ref=self.indicator_id)
         self.valid_misp_attribute = {
             "id": self.id,
             "event_id": "1",
             "object_id": "0",
             "object_relation": None,
             "category": "Network activity",
-            "type": "domain",
-            "value1": self.indicator,
-            "value2": "",
+            "type": "domain|ip",
+            "value1": self.domain_ioc,
+            "value2": self.ip_ioc,
             "to_ids": True,
-            "uuid": "5e1f2787-fcfc-4718-a58a-00b4c0a82f06",
+            "uuid": self.attr_uuid,
             "timestamp": str(self.raw_ts),
             "distribution": "5",
             "sharing_group_id": "0",
             "comment": "",
             "deleted": False,
             "disable_correlation": False,
-            "value": self.indicator,
+            "value": f"{self.domain_ioc}|{self.ip_ioc}",
             "Sighting": [],
             "Tag": [],
         }
@@ -100,29 +110,57 @@ class TestMessageMapping(unittest.TestCase):
         """
         )
 
-    def test_invalid_threatbus_sightings(self):
-        self.assertIsNone(map_to_misp(None))
-        self.assertIsNone(map_to_misp("Hello"))
-        self.assertIsNone(map_to_misp(self))
+    def test_invalid_stix_sightings(self):
+        self.assertIsNone(stix2_sighting_to_misp(None))
+        self.assertIsNone(stix2_sighting_to_misp("Hello"))
+        self.assertIsNone(stix2_sighting_to_misp(self))
 
-    def test_invalid_misp_intel(self):
-        self.assertIsNone(map_to_internal(None, None))
-        self.assertIsNone(map_to_internal(None, "delete"))
-        self.assertIsNone(map_to_internal(self.valid_misp_attribute, None))
-
-    def test_default_action_remove(self):
-        self.assertIsNotNone(map_to_internal(self.valid_misp_attribute, "FOOOO"))
-
-    def test_valid_misp_intel(self):
-        intel_data = IntelData(self.indicator, self.expected_intel_type, source="MISP")
-        expected_intel = Intel(self.ts, self.id, intel_data, Operation.ADD)
-        self.assertEqual(
-            map_to_internal(self.valid_misp_attribute, "add"), expected_intel
+    def test_invalid_misp_attributes(self):
+        self.assertIsNone(attribute_to_stix2_indicator(None, None, None))
+        self.assertIsNone(attribute_to_stix2_indicator(None, "delete", None))
+        self.assertIsNone(
+            attribute_to_stix2_indicator(self.valid_misp_attribute, None, None)
         )
 
-    def test_valid_threatbus_sighting(self):
-        sighting = Sighting(self.ts, self.id, {}, (self.indicator,))
-        self.assertIsNotNone(map_to_misp(sighting))
+    def test_default_action_remove(self):
+        self.assertIsNotNone(
+            attribute_to_stix2_indicator(
+                self.valid_misp_attribute, "INVALID_ACTION", None
+            )
+        )
+
+    def test_valid_misp_attributes(self):
+        indicator = attribute_to_stix2_indicator(self.valid_misp_attribute, "add", None)
+        self.assertEqual(indicator.type, self.indicator.type)
+        self.assertEqual(indicator.id, self.indicator.id)
+        self.assertEqual(indicator.created, self.indicator.created)
+        self.assertEqual(indicator.pattern, self.indicator.pattern)
+
+        single_value_valid_misp_attribute = self.valid_misp_attribute.copy()
+        single_value_valid_misp_attribute["type"] = "domain"
+        single_value_valid_misp_attribute["value"] = self.domain_ioc
+        single_value_valid_misp_attribute["value1"] = self.domain_ioc
+        single_value_valid_misp_attribute["value2"] = None
+        indicator = attribute_to_stix2_indicator(
+            single_value_valid_misp_attribute, "add", None
+        )
+        self.assertEqual(indicator.type, self.indicator.type)
+        self.assertEqual(indicator.id, self.indicator.id)
+        self.assertEqual(indicator.created, self.ts)
+        self.assertEqual(
+            indicator.pattern, f"[domain-name:value = '{self.domain_ioc}']"
+        )
+
+    def test_valid_misp_attribute_removal(self):
+        valid_misp_attribute = self.valid_misp_attribute.copy()
+        valid_misp_attribute["to_ids"] = False
+        update = attribute_to_stix2_indicator(valid_misp_attribute, "edit", None)
+        self.assertEqual(update, Update(self.indicator_id, Operation.REMOVE))
+
+    def test_valid_stix_sighting(self):
+        misp_sighting = stix2_sighting_to_misp(self.sighting)
+        self.assertIsNotNone(misp_sighting)
+        self.assertEqual(type(misp_sighting), MISPSighting)
 
     def test_invalid_tags(self):
         attr = self.valid_misp_msg["Attribute"]

--- a/tests/integration/test_misp_inmem.py
+++ b/tests/integration/test_misp_inmem.py
@@ -1,0 +1,106 @@
+import confuse
+from datetime import datetime
+from threatbus_misp import plugin as misp_plugin
+from threatbus_inmem import plugin as inmem_backbone
+from queue import Queue
+import time
+import unittest
+from tests.utils import zmq_sender
+import zmq
+
+
+class TestRoundtrips(unittest.TestCase):
+    def test_misp_plugin_indicator_roundtrip(self):
+        """
+        Backend agnostic message passing screnario. Sends a single MISP
+        Attribute via ZeroMQ to the Threat Bus MISP plugin and checks if the
+        sent message is parsed and forwarded correctly as new STIX-2 Indicator.
+        """
+        timestamp = 1614599635
+        misp_attribute_id = "5e1f2787-fcfc-4718-a58a-00b4c0a82f06"
+        misp_attribute_indicator = "example.com"
+        misp_attribute_type = "domain"
+        misp_json_attribute = f"""{{
+            "Attribute": {{
+                "id": "15",
+                "event_id": "1",
+                "object_id": "0",
+                "object_relation": null,
+                "category": "Network activity",
+                "type": "{misp_attribute_type}",
+                "value1": "{misp_attribute_indicator}",
+                "value2": "",
+                "to_ids": true,
+                "uuid": "{misp_attribute_id}",
+                "timestamp": "{timestamp}",
+                "distribution": "5",
+                "sharing_group_id": "0",
+                "comment": "",
+                "deleted": false,
+                "disable_correlation": false,
+                "value": "{misp_attribute_indicator}",
+                "Sighting": []
+            }},
+            "Event": {{
+                "id": "1",
+                "date": "{timestamp}",
+                "info": "adsf",
+                "uuid": "5e1ee79d-25c8-42bd-a386-0291c0a82f06",
+                "published": false,
+                "analysis": "0",
+                "threat_level_id": "1",
+                "org_id": "1",
+                "orgc_id": "1",
+                "distribution": "3",
+                "sharing_group_id": "0",
+                "Orgc": {{
+                    "id": "1",
+                    "uuid": "5e1edc98-3984-4321-9003-018bfb195b64",
+                    "name": "ORGNAME"
+                }}
+            }},
+            "action": "add"
+        }}"""
+
+        # emulate a Threat Bus execution environment
+        inq = Queue()
+        outq = Queue()
+        misp_zmq_pub_port = 50001
+        socket = zmq.Context().socket(zmq.PUB)
+        socket.bind(f"tcp://127.0.0.1:{misp_zmq_pub_port}")
+
+        config = confuse.Configuration("threatbus")
+        config["misp"].add({})
+        config["misp"]["zmq"].add({})
+        config["misp"]["zmq"]["host"] = "127.0.0.1"
+        config["misp"]["zmq"]["port"] = misp_zmq_pub_port
+        config["inmem"].add({})
+        config["console"] = False
+        config["file"] = False
+
+        # start MISP plugin and in-memory backbone
+        empty_callback = lambda x, y: None
+        misp_plugin.run(config, config, inq, empty_callback, empty_callback)
+        inmem_backbone.run(config, config, inq)
+        inmem_backbone.subscribe("stix2/indicator", outq)
+        time.sleep(0.5)
+
+        # send MISP attribute via ZMQ
+        socket.send_string(f"misp_json_attribute {misp_json_attribute}")
+
+        # wait for MISP plugin to parse the IoC and forward to backbone where
+        # this test's queue is subscribed at
+        ioc = outq.get(block=True)
+        outq.task_done()
+        outq.join()
+
+        self.assertEqual(ioc.created, datetime.fromtimestamp(timestamp))
+        self.assertEqual(ioc.id, f"indicator--{misp_attribute_id}")
+        self.assertEqual(ioc.pattern_type, "stix")
+        self.assertEqual(
+            ioc.pattern, f"[domain-name:value = '{misp_attribute_indicator}']"
+        )
+
+        # terminate worker threads from plugins
+        inmem_backbone.stop()
+        misp_plugin.stop()

--- a/tests/utils/zmq_sender.py
+++ b/tests/utils/zmq_sender.py
@@ -2,7 +2,7 @@
 
 import zmq
 import time
-from stix2 import Indicator
+from stix2 import Indicator, Sighting
 
 
 def send(topic, msg, host="127.0.0.1", port=50000, bind=True):
@@ -23,5 +23,9 @@ if __name__ == "__main__":
     indicator = Indicator(
         pattern="[domain-name:value = 'evil.com']", pattern_type="stix"
     )
+    sighting = Sighting(
+        sighting_of_ref="indicator--629a6400-8817-4bcb-aee7-8c74fc57482c",
+        custom_properties={"x_threatbus_source": "VAST"},
+    )
     send("stix2/indicator", indicator.serialize(), port=13372, bind=False)
-    # send("sighting", "hello", bind=False)
+    send("stix2/sighting", sighting.serialize(), port=13372, bind=False)

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -6,6 +6,17 @@ from stix2 import Indicator, Sighting, parse
 from stix2.parsing import dict_to_stix2
 from typing import Union
 
+## Threat Bus custom STIX-2 attributes
+@unique
+class ThreatBusSTIX2Constants(Enum):
+    # used in Sighting.custom_properties to reference the full STIX-2 Indicator
+    X_THREATBUS_INDICATOR = "x_threatbus_indicator"
+    # used in Sighting.custom_properties.context
+    X_THREATBUS_SOURCE = "x_threatbus_source"
+    X_THREATBUS_SIGHTING_CONTEXT = "x_threatbus_sighting_context"
+    # Indicates an update operation for the STIX-2 item. See Operation enum.
+    X_THREATBUS_UPDATE = "x_threatbus_update"
+
 
 @dataclass
 class Subscription:
@@ -28,18 +39,6 @@ class Operation(Enum):
 class MessageType(Enum):
     INDICATOR = auto()
     SIGHTING = auto()
-
-
-@dataclass()
-class Update:
-    """
-    An Update consists of at least an ID and Operation. The operation should be
-    applied to items with the updated ID.
-    TODO: specify content changes
-    """
-
-    id: str
-    operation: Operation
 
 
 @dataclass()

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -79,7 +79,7 @@ class SnapshotRequestEncoder(json.JSONEncoder):
             # let the base class default method raise the TypeError
             return json.JSONEncoder.default(self, req)
         return {
-            "type": type(SnapshotRequest).__name__.lower(),
+            "type": SnapshotRequest.__name__.lower(),
             "snapshot_type": int(req.snapshot_type.value),
             "snapshot_id": str(req.snapshot_id),
             "snapshot": int(req.snapshot.total_seconds()),
@@ -96,7 +96,7 @@ class SnapshotRequestDecoder(json.JSONDecoder):
 
     def decode_hook(self, dct: dict):
         type_ = dct.get("type", None)
-        if not type_ or type_ != type(SnapshotRequest).__name__.lower():
+        if not type_ or type_ != SnapshotRequest.__name__.lower():
             return dct
         if "snapshot_type" in dct and "snapshot_id" in dct and "snapshot" in dct:
             return SnapshotRequest(
@@ -116,7 +116,7 @@ class SnapshotEnvelopeEncoder(json.JSONEncoder):
             # let the base class default method raise the TypeError
             return json.JSONEncoder.default(self, env)
         return {
-            "type": type(SnapshotEnvelope).__name__.lower(),
+            "type": SnapshotEnvelope.__name__.lower(),
             "snapshot_type": int(env.snapshot_type.value),
             "snapshot_id": str(env.snapshot_id),
             "body": json.loads(
@@ -137,7 +137,7 @@ class SnapshotEnvelopeDecoder(json.JSONDecoder):
         type_ = dct.get("type", None)
         if not type_:
             return dct
-        if type_ != type(SnapshotEnvelope).__name__.lower():
+        if type_ != SnapshotEnvelope.__name__.lower():
             # decoders walk through nested objects first (bottom up).
             # try to parse nested stix2 objs per best-effort, else bubble up
             try:

--- a/threatbus/test_data.py
+++ b/threatbus/test_data.py
@@ -14,6 +14,7 @@ from data import (
     SnapshotRequestDecoder,
     SnapshotEnvelopeEncoder,
     SnapshotEnvelopeDecoder,
+    ThreatBusSTIX2Constants,
 )
 
 
@@ -33,6 +34,7 @@ class TestJsonConversions(unittest.TestCase):
             modified=self.created,
         )
 
+        self.sighting_source = "VAST"
         self.sighting_id = "sighting--df0f9a0e-c3b6-4f53-b0cf-5e9c454ee0cc"
         self.sighting_context = {
             "ts": "2017-03-03T23:56:09.652643840",
@@ -63,7 +65,6 @@ class TestJsonConversions(unittest.TestCase):
             },
             "event_type": "alert",
             "_extra": {"vast-ioc": "172.31.129.17"},
-            "source": "VAST",
         }
         self.sighting = Sighting(
             id=self.sighting_id,
@@ -71,8 +72,9 @@ class TestJsonConversions(unittest.TestCase):
             modified=self.created,
             sighting_of_ref=self.indicator_id,
             custom_properties={
-                "x_threatbus_sighting_context": self.sighting_context,
-                "x_threatbus_indicator": self.indicator,
+                ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: self.sighting_context,
+                ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value: self.indicator,
+                ThreatBusSTIX2Constants.X_THREATBUS_SOURCE.value: self.sighting_source,
             },
         )
 
@@ -140,7 +142,8 @@ class TestJsonConversions(unittest.TestCase):
         self.assertEqual(py_dict["body"]["created"], format_datetime(self.created))
         self.assertEqual(py_dict["body"]["sighting_of_ref"], self.indicator_id)
         self.assertEqual(
-            py_dict["body"]["x_threatbus_sighting_context"], self.sighting_context
+            py_dict["body"][ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value],
+            self.sighting_context,
         )
         self.assertEqual(py_dict["type"], SnapshotEnvelope.__name__.lower())
 
@@ -174,8 +177,9 @@ class TestJsonConversions(unittest.TestCase):
                 "type": "sighting",
                 "spec_version": "2.1",
                 "id": "{self.sighting_id}",
-                "x_threatbus_sighting_context": {json.dumps(self.sighting_context)},
-                "x_threatbus_indicator": {self.indicator.serialize()}
+                "{ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value}": {json.dumps(self.sighting_context)},
+                "{ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value}": {self.indicator.serialize()},
+                "{ThreatBusSTIX2Constants.X_THREATBUS_SOURCE.value}": "{self.sighting_source}"
             }}
         }}"""
         read_back = json.loads(encoded_envelope_sighting, cls=SnapshotEnvelopeDecoder)

--- a/threatbus/test_data.py
+++ b/threatbus/test_data.py
@@ -98,11 +98,11 @@ class TestJsonConversions(unittest.TestCase):
         self.assertEqual(py_dict["snapshot_type"], MessageType.SIGHTING.value)
         self.assertEqual(py_dict["snapshot_id"], self.snapshot_id)
         self.assertEqual(py_dict["snapshot"], self.snapshot.total_seconds())
-        self.assertEqual(py_dict["type"], type(SnapshotRequest).__name__.lower())
+        self.assertEqual(py_dict["type"], SnapshotRequest.__name__.lower())
 
     def test_valid_snapshot_request_decoding(self):
         encoded = f"""{{
-            "type": "{type(SnapshotRequest).__name__.lower()}",
+            "type": "{SnapshotRequest.__name__.lower()}",
             "snapshot_type": {MessageType.SIGHTING.value},
             "snapshot_id": "{self.snapshot_id}",
             "snapshot": {self.snapshot.total_seconds()}
@@ -132,7 +132,7 @@ class TestJsonConversions(unittest.TestCase):
         self.assertEqual(py_dict["body"]["id"], self.indicator_id)
         self.assertEqual(py_dict["body"]["pattern"], self.pattern)
         self.assertEqual(py_dict["body"]["pattern_type"], self.pattern_type)
-        self.assertEqual(py_dict["type"], type(SnapshotEnvelope).__name__.lower())
+        self.assertEqual(py_dict["type"], SnapshotEnvelope.__name__.lower())
 
         py_dict = json.loads(encoded_envelope_sighting)
         self.assertEqual(py_dict["snapshot_type"], MessageType.SIGHTING.value)
@@ -142,11 +142,11 @@ class TestJsonConversions(unittest.TestCase):
         self.assertEqual(
             py_dict["body"]["x_threatbus_sighting_context"], self.sighting_context
         )
-        self.assertEqual(py_dict["type"], type(SnapshotEnvelope).__name__.lower())
+        self.assertEqual(py_dict["type"], SnapshotEnvelope.__name__.lower())
 
     def test_valid_snapshot_envelope_decoding(self):
         encoded_envelope_indicator = f"""{{
-            "type": "{type(SnapshotEnvelope).__name__.lower()}",
+            "type": "{SnapshotEnvelope.__name__.lower()}",
             "snapshot_type": {MessageType.INDICATOR.value},
             "snapshot_id": "{self.snapshot_id}",
             "body": {{
@@ -164,7 +164,7 @@ class TestJsonConversions(unittest.TestCase):
         self.assertEqual(read_back, self.snapshot_envelope_indicator)
 
         encoded_envelope_sighting = f"""{{
-            "type": "{type(SnapshotEnvelope).__name__.lower()}",
+            "type": "{SnapshotEnvelope.__name__.lower()}",
             "snapshot_type": {MessageType.SIGHTING.value},
             "snapshot_id": "{self.snapshot_id}",
             "body": {{


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Following up on the STIX-2 rewrite of Threat Bus: this PR updates the MISP plugin.

- Convert MISP attributes to STIX-2 Indicators
- Convert STIX-2 Sightings to MISP sightings
- New message-passing integration test
- Updated unit tests

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
- Run the unit-tests (`make dev-mode && make unit-tests`)
- Fire up a local MISP or connect to our testbed and start Threat Bus using this branch
- Click some attributes in the MISP web view
- Send some sightings using our test utils