### PR TITLE
Use strict equality comparison in VAST queries

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -11,9 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🐞 bugfix
 
 ## Unreleased
+
 - ⚠️ The retro-matching now applies a strict equality comparison when mapping
-  IoCs to VAST queries. Prior to this change, `pyvast-threatbus` used substring
-  equality. That came at heavy runtime costs when issuing hundreds of queries
+  IoCs to VAST queries. Prior to this change `pyvast-threatbus` used substring
+  search, which came at heavy runtime costs when issuing hundreds of queries
   per second.
   [#104](https://github.com/tenzir/threatbus/pull/104)
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,12 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+- ⚠️ The retro-matching now applies a strict equality comparison when mapping
+  IoCs to VAST queries. Prior to this change, `pyvast-threatbus` used substring
+  equality. That came at heavy runtime costs when issuing hundreds of queries
+  per second.
+  [#104](https://github.com/tenzir/threatbus/pull/104)
 
 ## [2021.02.24]
 

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -91,7 +91,7 @@ def to_vast_query(intel: Intel):
     if vast_type == "url":
         return f'"{indicator}" in net.uri'
     if vast_type == "domain":
-        return f'"{indicator}" in net.domain || "{indicator}" in net.hostname'
+        return f'"{indicator}" == net.domain || "{indicator}" == net.hostname'
     return None
 
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->
This PR introduces a strict equality comparison when mapping Threat Bus IoCs to VAST queries for retro matching.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
n/t