### PR TITLE
Rewrite CIF3 plugin to convert STIX-2 Indicators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,8 @@ unit-tests:
 	$(MAKE) -C plugins/apps/threatbus_zmq_app unit-tests
 	$(MAKE) -C plugins/apps/threatbus_misp unit-tests
 	$(MAKE) -C plugins/apps/threatbus_zeek unit-tests
+	$(MAKE) -C plugins/apps/threatbus_cif3 unit-tests
 	$(MAKE) -C apps/vast unit-tests
-  # Threat Bus is currently being migrated to use STIX-2 as internal format.
-  # For the time being, all un-migrated plugins cannot be not tested against the
-  # current master
-	#$(MAKE) -C plugins/apps/threatbus_cif3 unit-tests
 
 .PHONY: integration-tests
 integration-tests:
@@ -96,7 +93,4 @@ dev-mode:
 	$(MAKE) -C plugins/apps/threatbus_misp dev-mode
 	$(MAKE) -C plugins/apps/threatbus_zeek dev-mode
 	$(MAKE) -C apps/vast dev-mode
-  # Threat Bus is currently being migrated to use STIX-2 as internal format.
-  # For the time being, all un-migrated plugins cannot be run in conjunction
-  # with current master
-	# $(MAKE) -C plugins/apps/threatbus_cif3 dev-mode
+	$(MAKE) -C plugins/apps/threatbus_cif3 dev-mode

--- a/plugins/apps/threatbus_cif3/README.md
+++ b/plugins/apps/threatbus_cif3/README.md
@@ -1,7 +1,23 @@
 Threat Bus CIFv3 Plugin
 ======================
 
-A Threat Bus plugin that enables communication to [Collective Intelligence Framework v3](https://github.com/csirtgadgets/bearded-avenger).
+<h4 align="center">
+
+[![PyPI Status][pypi-badge]][pypi-url]
+[![Build Status][ci-badge]][ci-url]
+[![License][license-badge]][license-url]
+
+</h4>
+
+A Threat Bus plugin to push indicators from Threat Bus to
+[Collective Intelligence Framework v3](https://github.com/csirtgadgets/bearded-avenger).
+
+The plugin uses the [cifsdk (v3.x)](https://pypi.org/project/cifsdk/) Python
+client to submit indicators received from Threat Bus into a CIFv3 instance.
+
+The plugin breaks with the pub/sub architecture of Threat Bus, because CIF does
+not subscribe itself to the bus. Instead, the plugin actively contacts a CIF
+endpoint.
 
 ## Installation
 
@@ -11,7 +27,8 @@ pip install threatbus-cif3
 
 ## Configuration
 
-The plugin uses the cifsdk python client to submit indicators received on the threatbus into a CIF instance.
+Configure this plugin by adding a section to Threat Bus' `config.yaml` file, as
+follows:
 
 ```yaml
 ...
@@ -32,7 +49,7 @@ plugins:
 
 ## Development Setup
 
-The following guides describe how to set up local, dockerized instances of MISP.
+The following guides describe how to set up local, dockerized instances of CIF.
 
 ### Dockerized CIFv3
 
@@ -52,7 +69,8 @@ docker-compose build
 ```sh
 vim docker-compose.yml
 ```
-Find the section `cif` in the configuration and edit the following as appropriate:
+Find the section `cif` in the configuration and edit the following as
+appropriate to bind port 5000 to your localhost:
 
 ```yaml
 cif:
@@ -67,13 +85,14 @@ cif:
 
 ```sh
 docker-compose up -d
-# get an interactive shell
+# Get an interactive shell in the container:
 docker-compose exec cif /bin/bash
-# become the cif user
+# Become the cif user:
 su cif
-# check to see if access tokens were successfully created
+# check to see if access tokens were successfully created. Copy the `admin`
+# token to the CIF config section:
 cif-tokens
-# ping the router to ensure connectivity
+# Ping the router to ensure connectivity:
 cif --ping
 ```
 
@@ -81,8 +100,8 @@ cif --ping
 
 Threat Bus comes with a [3-clause BSD license][license-url].
 
-[pypi-badge]: https://img.shields.io/pypi/v/threatbus-misp.svg
-[pypi-url]: https://pypi.org/project/threatbus-misp
+[pypi-badge]: https://img.shields.io/pypi/v/threatbus-cif3.svg
+[pypi-url]: https://pypi.org/project/threatbus-cif3
 [ci-url]: https://github.com/tenzir/threatbus/actions?query=branch%3Amaster
 [ci-badge]: https://github.com/tenzir/threatbus/workflows/Python%20Egg/badge.svg?branch=master
 [license-badge]: https://img.shields.io/badge/license-BSD-blue.svg

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -26,7 +26,8 @@ setup(
     description="A plugin to enable indicators to be submitted to CIFv3 in real-time",
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
     install_requires=[
-        "threatbus >= 2020.12.16, < 2021.2.24",
+        "stix2 >= 2.1",
+        "threatbus >= 2021.3.25",
         "cifsdk > 3.0.0rc4, < 4.0",
     ],
     keywords=[


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->
Following up on the STIX-2 rewrite of Threat Bus: this PR updates the CIF3 plugin.

- Convert STIX-2 Indicators to CIF3 Indicators

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Code review should be enough as this plugin has seen little attention and there are no unit tests, to begin with.

If you want to test interactively:
- Follow the instructions in the CIF3 plugin's readme to start a CIF3 container and copy the API TOKEN to your Threat Bus `config.yaml`
- Send Indicators via Threat Bus and confirm they make their way into CIF3 (e.g., see the logs)