### PR TITLE
Handle VAST matcher CLI changes in pyvast-threatbus

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,19 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- ⚠️ The previous VAST-Pro feature for threat intel matching has been
+  [rewritten](https://docs.tenzir.com/vast/features/threat-intel-matching)
+  as VAST plugin. This PR updates `pyvast-threatbus` to cope with the VAST CLI
+  changes introduced by that rewrite.
+  [#109](https://github.com/tenzir/threatbus/pull/109)
+
+- 🐞 We fixed a bug where VAST matcher results where passed to the wrong mapping
+  function after being retrieved from VAST.
+  [#109](https://github.com/tenzir/threatbus/pull/109)
+
+
 
 ## [2021.03.25]
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,10 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- ⚠️ The previous VAST-Pro feature for threat intel matching has been
-  [rewritten](https://docs.tenzir.com/vast/features/threat-intel-matching)
-  as VAST plugin. This PR updates `pyvast-threatbus` to cope with the VAST CLI
-  changes introduced by that rewrite.
+- ⚠️ VAST's proprietary
+  [Threat Intel Matching](https://docs.tenzir.com/vast/features/threat-intel-matching)
+  feature was rewritten as a VAST plugin. `pyvast-threatbus` now works with the
+  changed command line interface.
   [#109](https://github.com/tenzir/threatbus/pull/109)
 
 - 🐞 We fixed a bug where VAST matcher results where passed to the wrong mapping

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -54,7 +54,7 @@ def indicator_to_vast_matcher_ioc(indicator: Indicator) -> Union[str, None]:
 
     return json.dumps(
         {
-            "ioc": ioc_value,
+            "value": ioc_value,
             "type": vast_type,
             "reference": f"{threatbus_reference}{indicator.id}",
         }

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -462,7 +462,7 @@ async def live_match_vast(
                 # TODO reconnect
             continue
         vast_sighting = data.decode("utf-8").rstrip()
-        sighting = matcher_result_to_threatbus_sighting(vast_sighting)
+        sighting = matcher_result_to_sighting(vast_sighting)
         if not sighting:
             logger.error(f"Cannot parse sighting-output from VAST: {vast_sighting}")
             continue

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -350,7 +350,7 @@ async def ingest_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indic
         )
         return
     vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-    proc = await vast.import_().json(type="intel.indicator").exec(stdin=vast_ioc)
+    proc = await vast.import_(type="intel.indicator").json().exec(stdin=vast_ioc)
     await proc.wait()
     logger.debug(f"Ingested indicator for VAST live matching: {indicator}")
 

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -370,7 +370,8 @@ async def remove_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indic
         return None
     (vast_type, ioc_value) = type_and_value
     vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-    await vast.matcher().ioc_remove(matcher_name, ioc_value, vast_type).exec()
+    # TODO pass matcher_name once VAST supports more fine-grained deletion
+    await vast.matcher().intel().remove(ioc_value, vast_type).exec()
     logger.debug(f"Removed indicator from VAST live matching: {indicator}")
 
 

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -27,7 +27,7 @@ class TestMessageMapping(unittest.TestCase):
             id=self.indicator_id,
         )
         self.valid_query_result = f'{{"timestamp": "{self.ts}", "flow_id": 1840147514011873, "pcap_cnt": 626, "src_ip": "{self.ioc_value}", "src_port": 1193, "dest_ip": "65.54.95.64", "dest_port": 80, "proto": "TCP", "event_type": "http", "community_id": "1:AzSEWwmsqEKUX5qrReAHI3Rpizg=", "http": {{"hostname": "download.windowsupdate.com", "url": "/v9/windowsupdate/a/selfupdate/WSUS3/x86/Other/wsus3setup.cab?0911180916", "http_port": null, "http_user_agent": "Windows-Update-Agent", "http_content_type": "application/octet-stream", "http_method": "HEAD", "http_refer": null, "protocol": "HTTP/1.1", "status": 200, "redirect": null, "length": 0}}, "tx_id": 0}}'
-        self.valid_matcher_result = f'{{"ts": "{self.ts}", "data_id": 8, "indicator_id": 5, "matcher": "threatbus-syeocdkfcy", "ioc": "{self.ioc_value}", "reference": "threatbus__{self.indicator_id}"}}'
+        self.valid_matcher_result = f'{{"ts": "{self.ts}", "data_id": 8, "indicator_id": 5, "matcher": "threatbus-syeocdkfcy", "value": "{self.ioc_value}", "reference": "threatbus__{self.indicator_id}"}}'
 
     def test_vast_escape_str(self):
         self.assertEqual(vast_escape_str('e"vil.com'), 'e\\"vil.com')
@@ -73,7 +73,7 @@ class TestMessageMapping(unittest.TestCase):
     def test_indicator_to_vast_matcher_ioc(self):
         expected_vast_ioc = json.dumps(
             {
-                "ioc": self.ioc_value,
+                "value": self.ioc_value,
                 "type": "ip",
                 "reference": f"threatbus__{self.indicator_id}",
             }
@@ -147,9 +147,9 @@ class TestMessageMapping(unittest.TestCase):
         self.assertIsNone(matcher_result_to_sighting(42))
         self.assertIsNone(matcher_result_to_sighting(object))
         self.assertIsNone(matcher_result_to_sighting("some non-json string"))
-        sighting_with_malformed_reference = '{"ts": "2020-09-24T08:43:43.654072335", "ioc": "foo", "reference": "threatbus__86"}'
+        sighting_with_malformed_reference = '{"ts": "2020-09-24T08:43:43.654072335", "value": "foo", "reference": "threatbus__86"}'
         self.assertIsNone(matcher_result_to_sighting(sighting_with_malformed_reference))
-        sighting_with_malformed_timestamp = '{"ts": "2020 T08 :43.654072335", "ioc": "foo", "reference": "threatbus__indicator--46b3f973-5c03-41fc-9efe-49598a267a35"}'
+        sighting_with_malformed_timestamp = '{"ts": "2020 T08 :43.654072335", "value": "foo", "reference": "threatbus__indicator--46b3f973-5c03-41fc-9efe-49598a267a35"}'
         self.assertIsNone(matcher_result_to_sighting(sighting_with_malformed_timestamp))
 
     def test_matcher_result_to_sighting(self):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The VAST matcher is now available as [plugin](https://docs.tenzir.com/vast/features/threat-intel-matching). That rewrite led to a CLI change.

This PR updates `pyvast-threatbus` to use the correct CLI options to work with the VAST matcher plugin. It also fixes a small bug where the wrong function name was called for mapping matcher results to STIX-2 sightings.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
