### PR TITLE
Add timeout option for retro-queries

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+
+- 🎁 `pyvast-threatbus` now supports a new config option to set timeouts for
+  VAST retro-queries: `retro_match_timeout`. Pending queries are killed upon
+  timeout. VAST results that were exported before the timeout hit are still
+  reported as valid Sightings.
+  [#110](https://github.com/tenzir/threatbus/pull/110)
+
 - ⚠️ VAST's proprietary
   [Threat Intel Matching](https://docs.tenzir.com/vast/features/threat-intel-matching)
   feature was rewritten as a VAST plugin. `pyvast-threatbus` now works with the

--- a/apps/vast/config.yaml.example
+++ b/apps/vast/config.yaml.example
@@ -17,7 +17,7 @@ snapshot: 30
 live_match: false
 retro_match: true
 retro_match_max_events: 0 # set to 0 for unlimited results
-unflatten: true
+retro_match_timeout: 5 # set to 0 for no timeout
 # optional. remove the field if you don't want to transform sighting context
 transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc
 # optional. remove the field if you simply want to report back sightings to Threat Bus

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -1,5 +1,4 @@
 from dateutil import parser as dateutil_parser
-from ipaddress import ip_address
 import json
 from stix2 import Indicator, Sighting
 from threatbus.data import ThreatBusSTIX2Constants

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -13,7 +13,6 @@ from .message_mapping import (
     indicator_to_vast_query,
     matcher_result_to_sighting,
     query_result_to_sighting,
-    split_object_path_and_value,
 )
 from pyvast import VAST
 import random

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import unittest
 import json
-from stix2 import Indicator, Sighting, parse
+from stix2 import Indicator, Sighting
 from threatbus.data import Operation, ThreatBusSTIX2Constants
 from .message_mapping import (
     get_vast_type_and_value,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Add a config option to timeout VAST retro-queries.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file

Interactively: try setting a small timeout (e.g., 0.1) and verify the query is aborted.