### PR TITLE
Fix sighting context post-processing

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 We fixed an unhandled exception in the post-processing of sighting context
+  data for both retro- and live-matched sightings. The bug was introduced with
+  the STIX-2 rewrite and effectively rendered both the `transform_context` and
+  `sink` options unusable.
+  [#112](https://github.com/tenzir/threatbus/pull/112)
 
 - 🎁 `pyvast-threatbus` now supports a new config option to set timeouts for
   VAST retro-queries: `retro_match_timeout`. Pending queries are killed upon

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -132,6 +132,7 @@ def matcher_result_to_sighting(matcher_result: str) -> Union[Sighting, None]:
         return None
     ref = dct.get("reference", "")
     context = dct.get("context", {})
+    ioc_value = dct.get("value", "")
     # ref = threatbus__indicator--46b3f973-5c03-41fc-9efe-49598a267a35
     ref_len = len(threatbus_reference) + len("indicator--") + 36
     if not ts or not ref or not len(ref) == ref_len:
@@ -142,6 +143,7 @@ def matcher_result_to_sighting(matcher_result: str) -> Union[Sighting, None]:
         created=ts,
         sighting_of_ref=ref,
         custom_properties={
-            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context
+            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,
+            ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR_VALUE.value: ioc_value,
         },
     )

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -106,7 +106,8 @@ def query_result_to_sighting(
             created=dateutil_parser.parse(ts),
             sighting_of_ref=indicator.id,
             custom_properties={
-                ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context
+                ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,
+                ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value: indicator,
             },
         )
     except Exception:

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -543,7 +543,7 @@ async def report_sightings(
     @param transform_cmd The command to use to pipe sightings to. Treated
         as template string: occurrences of '%ioc' in the cmd string get replaced
         with the matched IoC.
-    @param report_data If True, only report context data of the sighting instead.data instead of the
+    @param report_data If True, only report context data of the sighting instead
         of the whole thing.
     """
     global logger

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -11,6 +11,9 @@ from typing import Union
 class ThreatBusSTIX2Constants(Enum):
     # used in Sighting.custom_properties to reference the full STIX-2 Indicator
     X_THREATBUS_INDICATOR = "x_threatbus_indicator"
+    # used in Sighting.custom_properties to reference the Indicator value, in
+    # case the full indicator is not present any more.
+    X_THREATBUS_INDICATOR_VALUE = "x_threatbus_indicator_value"
     # used in Sighting.custom_properties.context
     X_THREATBUS_SOURCE = "x_threatbus_source"
     X_THREATBUS_SIGHTING_CONTEXT = "x_threatbus_sighting_context"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Fix a bug with sighting context post-processing (both custom sinks and context transformation). 

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Enable both live- and retro-matching and test interactively by passing sighting context into fever alertify (use example config).