### PR TITLE
Fix spelling of changelog categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ This changelog documents all notable user-facing changes of Threat Bus.
 
 Every entry has a category for which we use the following visual abbreviations:
 
-- 🎁 Feature
-- ⚠️ Change
-- ⚡️ Breaking Change
-- 🧬 Experimental feature
-- 🐞 Bugfix
+- 🎁 Features
+- ⚠️ Changes
+- ⚡️ Breaking Changes
+- 🧬 Experimental Features
+- 🐞 Bug Fixes
 
 <!-- ## Unreleased -->
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -4,11 +4,11 @@ This changelog documents all notable user-facing changes of `pyvast-threatbus`.
 
 Every entry has a category for which we use the following visual abbreviations:
 
-- 🎁 feature
-- 🧬 experimental feature
-- ⚠️ change
-- ⚡️ breaking change
-- 🐞 bugfix
+- 🎁 Features
+- 🧬 Experimental Features
+- ⚠️ Changes
+- ⚡️ Breaking Changes
+- 🐞 Bug Fixes
 
 ## Unreleased
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The categories were inconsistently spelled. Noticed this when going through the release notes.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

:shrug: