### PR TITLE
Properly use the `last_seen` attribute of STIX-2 Sightings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental Features
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- ⚠️ The `threatbus-zeek` plugin now uses the timestamp of Zeek intel matches to
+  set the `last_seen` property of resulting STIX-2 Sightings, instead of setting
+  the `created` timestamp. The `created` timestamp now always refers to the
+  actual creation time of the sightings.
+  [#117](https://github.com/tenzir/threatbus/pull/117)
+
 
 ## [2021.04.29]
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,14 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- ⚠️ `pyvast-threatbus` now uses the timestamp of retro- & live-matches to set
+  the `last_seen` property of STIX-2 Sightings, instead of setting the `created`
+  timestamp. The `created` timestamp now always refers to the actual creation
+  time of the sightings.
+  [#117](https://github.com/tenzir/threatbus/pull/117)
+
 
 ## [2021.04.29]
 

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -101,9 +101,9 @@ def query_result_to_sighting(
         ts = context.get("ts", context.get("timestamp", None))
         if not ts:
             return None
-
+        ts = dateutil_parser.parse(ts)
         return Sighting(
-            created=dateutil_parser.parse(ts),
+            last_seen=ts,
             sighting_of_ref=indicator.id,
             custom_properties={
                 ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,
@@ -140,7 +140,7 @@ def matcher_result_to_sighting(matcher_result: str) -> Union[Sighting, None]:
     ref = ref[len(threatbus_reference) :]
     context["source"] = "VAST"
     return Sighting(
-        created=ts,
+        last_seen=ts,
         sighting_of_ref=ref,
         custom_properties={
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -132,7 +132,7 @@ class TestMessageMapping(unittest.TestCase):
         )
         self.assertIsNotNone(parsed_sighting)
         self.assertEqual(type(parsed_sighting), Sighting)
-        self.assertEqual(parsed_sighting.created, self.ts)
+        self.assertEqual(parsed_sighting.last_seen, self.ts)
         self.assertEqual(parsed_sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
@@ -156,7 +156,7 @@ class TestMessageMapping(unittest.TestCase):
         parsed_sighting = matcher_result_to_sighting(self.valid_matcher_result)
         self.assertIsNotNone(parsed_sighting)
         self.assertEqual(type(parsed_sighting), Sighting)
-        self.assertEqual(parsed_sighting.created, self.ts)
+        self.assertEqual(parsed_sighting.last_seen, self.ts)
         self.assertEqual(parsed_sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value

--- a/plugins/apps/threatbus_zeek/threatbus_zeek/message_mapping.py
+++ b/plugins/apps/threatbus_zeek/threatbus_zeek/message_mapping.py
@@ -81,8 +81,8 @@ def map_broker_event_to_sighting(broker_data, module_namespace, logger):
     # convert args to STIX-2 sighting
     (timestamp, ioc_id, context) = args
     return Sighting(
-        created=timestamp,
         sighting_of_ref=str(ioc_id),
+        last_seen=timestamp,
         custom_properties={
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context
         },

--- a/plugins/apps/threatbus_zeek/threatbus_zeek/test_message_mapping.py
+++ b/plugins/apps/threatbus_zeek/threatbus_zeek/test_message_mapping.py
@@ -147,7 +147,7 @@ class TestMessageMapping(unittest.TestCase):
         event = broker.zeek.Event("sighting", self.ts, self.indicator_id, context)
         sighting = map_broker_event_to_sighting(event, self.module_namespace, None)
         self.assertEqual(type(sighting), Sighting)
-        self.assertEqual(sighting.created, self.ts)
+        self.assertEqual(sighting.last_seen, self.ts)
         self.assertEqual(sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
@@ -161,7 +161,7 @@ class TestMessageMapping(unittest.TestCase):
         )
         sighting = map_broker_event_to_sighting(event, self.module_namespace, None)
         self.assertEqual(type(sighting), Sighting)
-        self.assertEqual(sighting.created, self.ts)
+        self.assertEqual(sighting.last_seen, self.ts)
         self.assertEqual(sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Set `last_seen` correctly with `pyvast-threatbus` and the Zeek plugin
- Fix usage of the `created` timestamp field

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
- File-by-file.
- Run the unit tests