### PR TITLE
Print help text when starting without a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The `-c` / `--config` parameter is now explicitly required to start
+  Threat Bus. Starting without it will print a helpful error message.
+  [#119](https://github.com/tenzir/threatbus/pull/119)
+
 - ⚠️ The `threatbus-zeek` plugin now uses the timestamp of Zeek intel matches to
   set the `last_seen` property of resulting STIX-2 Sightings, instead of setting
   the `created` timestamp. The `created` timestamp now always refers to the

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The `-c` / `--config` parameter is now explicitly required to start
+  `pyvast-threatbus`. Starting without it will print a helpful error message.
+  [#119](https://github.com/tenzir/threatbus/pull/119)
+
 - ⚠️ `pyvast-threatbus` now uses the timestamp of retro- & live-matches to set
   the `last_seen` property of STIX-2 Sightings, instead of setting the `created`
   timestamp. The `created` timestamp now always refers to the actual creation

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -743,7 +743,10 @@ async def heartbeat(endpoint: str, p2p_topic: str, interval: int = 5):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", "-c", help="Path to a configuration file")
+    required_group = parser.add_argument_group("required named arguments")
+    required_group.add_argument(
+        "--config", "-c", help="path to a configuration file", required=True
+    )
     args = parser.parse_args()
 
     # we need to use an underscore in the configuration name "pyvast_threatbus"

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -198,7 +198,10 @@ def start(config: confuse.Subview):
 def main():
     config = confuse.Configuration("threatbus")
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", "-c", help="path to a configuration file")
+    required_group = parser.add_argument_group("required named arguments")
+    required_group.add_argument(
+        "--config", "-c", help="path to a configuration file", required=True
+    )
     args = parser.parse_args()
     config.set_args(args)
     if args.config:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Threat Bus & pyvast-threatbus now require the `-c` / `--config` parameter and print an error message if it Is not provided.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.