### PR TITLE
Subscribe multiple topics with a single subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 Threat Bus now supports subscriptions for multiple topics. The
+  `zmq-app-plugin` implements those multi-topic subscriptions in a
+  backwards-compatible way. Subscribers benefit from this change, as they only
+  get assigned a single point-to-point topic for their subscription, instead of
+  one point-to-point topic for every subscribed Threat Bus topic.
+  [#120](https://github.com/tenzir/threatbus/pull/120)
+
 - ⚠️ The `-c` / `--config` parameter is now explicitly required to start
   Threat Bus. Starting without it will print a helpful error message.
   [#119](https://github.com/tenzir/threatbus/pull/119)

--- a/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/message_mapping.py
+++ b/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/message_mapping.py
@@ -5,6 +5,9 @@ from threatbus.data import Subscription, Unsubscription
 
 @dataclass
 class Heartbeat:
+    # the p2p_topic used for point-to-point communication between the host and
+    # the subscriber, not a human-readable topic. I.e., the random string that
+    # was sent as respons from the Threat Bus host during subscription.
     topic: str
 
 

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -4,7 +4,7 @@ from enum import auto, Enum, unique
 import json
 from stix2 import Indicator, Sighting, parse
 from stix2.parsing import dict_to_stix2
-from typing import Union
+from typing import List, Union
 
 ## Threat Bus custom STIX-2 attributes
 @unique
@@ -23,12 +23,16 @@ class ThreatBusSTIX2Constants(Enum):
 
 @dataclass
 class Subscription:
-    topic: str
+    # either a single topic or a list of topics, e.g., `stix2/indicator`
+    topic: Union[str, List[str]]
     snapshot: timedelta
 
 
 @dataclass
 class Unsubscription:
+    # the p2p_topic used for point-to-point communication between the host and
+    # the subscriber, not a human-readable topic. I.e., the random string that
+    # was sent as respons from the Threat Bus host during subscription.
     topic: str
 
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Subscribers can now subscribe for multiple Threat Bus topics by sending a single `Subscription` message. That is of advantage to the previous implementation, because subscribers now only get to deal with a single `p2p_topic` for their subscription instead of one `p2p_topic` per subscribed Threat Bus topic.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
- Run the integration tests
- Use the `zmq_sender` and `zmq_receiver` in `tests/utils` for interactive testing