### PR TITLE
Improve net.uri queries in pyvast-threatbus

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,13 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- ⚠️ `pyvast-threatbus` now uses point queries over substring queries for URI
+  indicators, because such queries are much faster. For URI indicators without a
+  protocol identifier `pyvast-threatbus` issues additional queries for the
+  indicator prefixed with common identifiers like `http://` and `tcp://`.
+  [#124](https://github.com/tenzir/threatbus/pull/124)
 
 ## [2021.05.27]
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Substring queries in VAST are slow compared to point queries. Instead of using `in` to query for the concept `net.uri`, we use strict equality in case the indicator begins with a protocol identifier, and otherwise search for the indicator and the indicator prefixed with common prefixes like `http://` or `tcp://` instead.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally.