### PR TITLE
Report back Sightings from STIX-Shifter to Threat Bus

### DIFF
--- a/apps/stix-shifter/CHANGELOG.md
+++ b/apps/stix-shifter/CHANGELOG.md
@@ -11,7 +11,16 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 `stix-shifter-threatbus` now reports back STIX-2 Sightings to Threat Bus.
+  STIX-Shifter transmission results are first translated, using the respective
+  native STIX-Shifter module's translation function. The resulting STIX-2.0
+  bundles are then traversed to create sightings for every contained
+  observation. These sightings are then finally returned to Threat Bus via
+  ZeroMQ. The original observation objects are kept in each sighting's context
+  data.
+
 
 ## [2021.05.27]
 

--- a/apps/stix-shifter/setup.py
+++ b/apps/stix-shifter/setup.py
@@ -32,6 +32,7 @@ setup(
         "black >= 19.10b",
         "coloredlogs >= 14.0",
         "confuse",
+        "python-dateutil",
         "pyzmq >= 19",
         "stix2 >= 2.1",
         "stix-shifter >= 3.4.2",

--- a/apps/stix-shifter/stix_shifter_threatbus/message_mapping.py
+++ b/apps/stix-shifter/stix_shifter_threatbus/message_mapping.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from dateutil import parser as dateutil_parser
+from stix2 import Indicator, Sighting
+from threatbus.data import ThreatBusSTIX2Constants
+from typing import Dict, List
+
+
+def map_bundle_to_sightings(indicator: Indicator, observations: List[Dict]):
+    """
+    # Generate one STIX-2 Sighting per `observed-data` entry in the list of
+    STIX objects
+    @param indicator: the STIX-2 indicators that all observations refer to
+    @param observations: a list of STIX-2 observations to map to Sightings
+    @return iterator over Sighting objects
+    """
+    for obj in observations:
+        if obj.get("type", None) != "observed-data":
+            continue
+        last = dateutil_parser.parse(obj.get("last_observed", str(datetime.now())))
+        yield Sighting(
+            last_seen=last,
+            sighting_of_ref=indicator.id,
+            custom_properties={
+                ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: obj,
+                ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value: indicator,
+            },
+        )

--- a/apps/stix-shifter/stix_shifter_threatbus/test_message_mapping.py
+++ b/apps/stix-shifter/stix_shifter_threatbus/test_message_mapping.py
@@ -1,0 +1,30 @@
+import unittest
+from stix2 import Indicator, Sighting
+from .message_mapping import map_bundle_to_sightings
+
+
+class TestMessageMapping(unittest.TestCase):
+    def setUp(self):
+        self.observations = [
+            {
+                "type": "identity",
+            },
+            {"type": "observed-data", "some-prop": "value"},
+            {
+                "type": "observed-data",
+                "some-prop": "value",
+                "last_observed": "2021-05-04T15:15:58.919Z",
+            },
+        ]
+        self.indicator = Indicator(
+            pattern="[ipv4-addr:value = '6.6.6.6']", pattern_type="stix"
+        )
+
+    def test_map_bundle(self):
+        mapped = list(map_bundle_to_sightings(self.indicator, self.observations))
+        self.assertEqual(len(mapped), 2)
+
+        for sighting in mapped:
+            self.assertEqual(type(sighting), Sighting)
+            self.assertEqual(sighting.sighting_of_ref, self.indicator.id)
+            self.assertIsNotNone(sighting.last_seen)

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -30,6 +30,7 @@ setup(
         "black >= 19.10b",
         "coloredlogs >= 14.0",
         "confuse",
+        "python-dateutil",
         "pyzmq >= 19",
         "pyvast >= 2020.10.29",
         "stix2 >= 2.1",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR equips the `stix-shifter-threatbus` app to report back sightings to Threat Bus.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Commit-by-commit.
Interactive: Use the ` tests/utils/zmq_sender.py` test util to send indicators to STIX-Shifter and connect it with e.g., Splunk. Splunk results should find their way back into Threat Bus as STIX-2 Sightings.