### PR TITLE
Collect metrics about received but unprocessed IoCs in pyvast-threatbus

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,14 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 `pyvast-threatbus` now collects metrics about received indicators that are
+  about to be matched retrospectively against VAST. The new metric is called
+  `retro_match_backlog` and allows users to determine if a backlog is
+  building up. A backlog builds when `pyvast-threatbus` hits the
+  user-configured limit of max backgroud tasks while at the same time VAST
+  responds slowly to the issued queries.
+  [#129]https://github.com/tenzir/threatbus/pull/129
+
 - 🎁 `pyvast-threatbus` now comes with its own Dockerfile. Pre-built images are
   available on [Dockerhub](https://hub.docker.com/r/tenzir/pyvast-threatbus).
   [#126](https://github.com/tenzir/threatbus/pull/126)

--- a/apps/vast/pyvast_threatbus/metrics.py
+++ b/apps/vast/pyvast_threatbus/metrics.py
@@ -112,7 +112,7 @@ class InfiniteGauge(Gauge):
     def inc(self):
         """
         Increase the gauge value. Automatically resets it in case the value
-        equlas 0 after this operation.
+        equals 0 after this operation.
         """
         super(InfiniteGauge, self).inc()
         if self.value == self.initial_value:

--- a/apps/vast/pyvast_threatbus/metrics.py
+++ b/apps/vast/pyvast_threatbus/metrics.py
@@ -89,3 +89,40 @@ class Gauge(Metric):
         super(Gauge, self).reset()
         with self._lock:
             self.value = 0
+
+
+class InfiniteGauge(Gauge):
+    """
+    A simple numeric gauge that can go up and down. This gauge can never be
+    resetted by a function call. Instead, it resets automatically when it's
+    value reaches the initial value of `0`.
+    """
+
+    def __init__(self, name: str):
+        super(InfiniteGauge, self).__init__(name)
+        self.value = 0
+        self.initial_value = 0
+
+    def __reset(self):
+        super(InfiniteGauge, self).reset()
+
+    def reset(self):
+        pass
+
+    def inc(self):
+        """
+        Increase the gauge value. Automatically resets it in case the value
+        equlas 0 after this operation.
+        """
+        super(InfiniteGauge, self).inc()
+        if self.value == self.initial_value:
+            self.__reset()
+
+    def dec(self):
+        """
+        Decrease the gauge value. Automatically resets it in case the value
+        equlas 0 after this operation.
+        """
+        super(InfiniteGauge, self).dec()
+        if self.value == self.initial_value:
+            self.__reset()

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -21,7 +21,7 @@ from shlex import split as lexical_split
 import socket
 from string import ascii_lowercase as letters
 import sys
-from .metrics import Gauge, Summary
+from .metrics import Gauge, InfiniteGauge, Summary
 from stix2 import parse, Indicator, Sighting
 from threatbus.logger import setup as setup_logging_threatbus
 from threatbus.data import Operation, ThreatBusSTIX2Constants
@@ -37,13 +37,18 @@ matcher_name = None
 async_tasks = []
 # The p2p topic that was given to the vast-bridge upon successful subscription.
 p2p_topic = None
-max_open_tasks = None
 # Boolean flag indicating that the user has issued a SIGNAL (e.g., SIGTERM).
 user_exit = False
+# An asyncio.Semaphore to control the amount of concurrent retro-match tasks.
+max_open_tasks = None
+# Set of all started but unfinished retro-match tasks. They may stack up when
+# users set `max_background_tasks` in the config.
+open_retro_match_tasks = set()
 
 # Metric definitions.
 metrics = []
 g_iocs_added = Gauge("added_iocs")
+g_retro_match_backlog = InfiniteGauge("retro_match_backlog")
 g_iocs_removed = Gauge("removed_iocs")
 metrics += [g_iocs_added, g_iocs_removed]
 s_retro_matches_per_ioc = Summary("retro_matches_per_ioc")
@@ -228,7 +233,11 @@ async def start(
 
     if retro_match:
         # add metrics for retro-matching to the metric output
-        metrics += [s_retro_matches_per_ioc, s_retro_query_time_s_per_ioc]
+        metrics += [
+            s_retro_matches_per_ioc,
+            s_retro_query_time_s_per_ioc,
+            g_retro_match_backlog,
+        ]
     if live_match:
         # add metrics for live-matching to the metric output
         metrics.append(g_live_matcher_sightings)
@@ -261,7 +270,7 @@ async def write_metrics(every: int, to: str):
         for m in metrics:
             if not m.is_set:
                 continue
-            if type(m) is Gauge:
+            if type(m) is Gauge or type(m) is InfiniteGauge:
                 line += f" {m.name}={m.value}"
             if type(m) is Summary:
                 line += (
@@ -274,7 +283,6 @@ async def write_metrics(every: int, to: str):
             line += f" {time.time_ns()}"  # append current nanoseconds ts
             with open(to, "a") as f:
                 f.write(line + "\n")
-
         await asyncio.sleep(every)
 
 
@@ -370,6 +378,7 @@ async def retro_match_vast(
         logger.debug(f"Retro-matched {reported} sighting(s) for indicator: {indicator}")
         s_retro_matches_per_ioc.observe(reported)
         s_retro_query_time_s_per_ioc.observe(time.time() - start)
+        g_retro_match_backlog.dec()
 
 
 async def ingest_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indicator):
@@ -462,6 +471,7 @@ async def match_intel(
             # add new Indicator to matcher / query Indicator retrospectively
             g_iocs_added.inc()
             if retro_match:
+                g_retro_match_backlog.inc()
                 asyncio.create_task(
                     retro_match_vast(
                         vast_binary,

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -340,6 +340,7 @@ async def retro_match_vast(
     start = time.time()
     query = indicator_to_vast_query(indicator)
     if not query:
+        g_retro_match_backlog.dec()
         return
     global logger, max_open_tasks
     async with max_open_tasks:
@@ -360,6 +361,7 @@ async def retro_match_vast(
                 f"Timeout after {retro_match_timeout}s in retro-query for indicator {indicator}"
             )
         if not retro_result or len(retro_result) != 2:
+            g_retro_match_backlog.dec()
             return
         reported = 0
         stdout = retro_result[0]

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -41,9 +41,6 @@ p2p_topic = None
 user_exit = False
 # An asyncio.Semaphore to control the amount of concurrent retro-match tasks.
 max_open_tasks = None
-# Set of all started but unfinished retro-match tasks. They may stack up when
-# users set `max_background_tasks` in the config.
-open_retro_match_tasks = set()
 
 # Metric definitions.
 metrics = []


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Add a new metric type called `InfiniteGauge` to track the size of a growing/shrinking backlog of Indicators that are received by `pyvast-threatbus`, but not yet processed by VAST.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run the code interactively and verify these metrics are visible in the `metrics.log` file