### PR TITLE
Use point for URI indicators in pyvast-threatbus

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚡️ `pyvast-threatbus` now uses point queries over substring queries for
+  URI indicators, because such queries are much faster. This may result
+  in less matches than before. E.g., a URI indicator `tenzir.com` that
+  used to match `docs.tenzir.com` as well as `https://tenzir.com` now
+  only matches exactly the indicator.
+
 - 🎁 `pyvast-threatbus` now collects metrics about received indicators that are
   about to be matched retrospectively against VAST. The new metric is called
   `retro_match_backlog` and allows users to determine if a backlog is

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -77,7 +77,7 @@ def indicator_to_vast_query(indicator: Indicator) -> Union[str, None]:
     if vast_type == "ip" or vast_type == "ipv6":
         return ioc_value
     if vast_type == "url":
-        return f'"{ioc_value}" in net.uri'
+        return f'"{ioc_value}" == net.uri'
     if vast_type == "domain":
         return f'"{ioc_value}" == net.domain || "{ioc_value}" == net.hostname'
     return None

--- a/apps/vast/pyvast_threatbus/test_message_mapping.py
+++ b/apps/vast/pyvast_threatbus/test_message_mapping.py
@@ -98,7 +98,7 @@ class TestMessageMapping(unittest.TestCase):
 
         ## test URL
         url = "example.com/foo/bar?query=123"
-        expected_vast_query = f'"{url}" in net.uri'
+        expected_vast_query = f'"{url}" == net.uri'
         other_ioc = Indicator(pattern_type="stix", pattern=f"[url:value = '{url}']")
         self.assertEqual(expected_vast_query, indicator_to_vast_query(other_ioc))
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Point queries are much faster than substring queries with VAST, so let's use them here as well to avoid unexpectedly long-running queries.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

:shrug: