### PR TITLE
Implement Suricata App for ingesting rules from Threat Bus

### DIFF
--- a/apps/suricata/CHANGELOG.md
+++ b/apps/suricata/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+This changelog documents all notable user-facing changes of
+`suricata-threatbus`.
+
+Every entry has a category for which we use the following visual abbreviations:
+
+- 🎁 Features
+- 🧬 Experimental Features
+- ⚠️ Changes
+- ⚡️ Breaking Changes
+- 🐞 Bug Fixes
+
+## Unreleased
+
+- 🎁 `suricata-threatbus` has come to life. This stand-alone application
+  connects to Threat Bus via ZeroMQ and bridges the gap between Threat Bus and
+  [Suricata](https://suricata.io/). `suricata-threatbus` maintains a custom
+  rule file for Suricata to read from. That allows users users to sync their
+  Suricata rules from other Threat Bus-connected tools, such as OpenCTI, with
+  their Suricata IDS installations.
+  [#131](https://github.com/tenzir/threatbus/pull/131)
+

--- a/apps/suricata/Makefile
+++ b/apps/suricata/Makefile
@@ -1,0 +1,36 @@
+colon := :
+$(colon) := :
+
+.PHONY: all
+all: format build dist test
+
+.PHONY: format
+format:
+	python -m black .
+
+.PHONY: test
+test: unit-tests
+
+.PHONY: unit-tests
+unit-tests:
+	python -m unittest discover .
+
+.PHONY: clean
+clean:
+	${RM} -r __pycache__ *egg-info build dist
+
+.PHONY: build
+build:
+	python setup.py build
+
+.PHONY: dist
+dist:
+	python setup.py sdist bdist_wheel
+
+.PHONY: install
+install:
+	pip install .
+
+.PHONY: dev-mode
+dev-mode:
+	pip install --editable .

--- a/apps/suricata/README.md
+++ b/apps/suricata/README.md
@@ -1,0 +1,65 @@
+Suricata Threat Bus App
+=======================
+
+Threat Bus is a publish-subscribe broker for threat intelligence. It is expected
+that applications register themselves at the bus. Since Suricata can't do that
+on it's own (yet) this app works as a bridge application in the meantime.
+
+It receives indicators from Threat Bus and picks up all those where the STIX-2
+`pattern_type` equals `"suricata"`. The suricata rules from those IoCs are then
+forwarded to Suricata using a pre-configured rules file and then reloaded via
+[suricatasc](https://suricata.readthedocs.io/en/latest/manpages/suricatasc.html).
+
+Make sure to run this app on the same host as your Suricata installation.
+Make also sure that this app (e.g., user running this app) has the correct
+permissions to use the `suricatasc` command line utility and can read/write the
+rules file.
+
+## Quick Start
+
+You can configure the app via a YAML configuration file. See
+`config.yaml.example` for an example config file.
+
+Install `suricata-threatbus` in a virtualenv and start it with a config file:
+
+```sh
+python -m venv venv
+source venv/bin/activate
+make dev-mode
+suricata-threatbus -c config.yaml
+```
+
+You first need to configure the `rules_file` option in the config file. See also
+below for configuring your local Suricata installation to work with this app.
+
+### Suricata Preparation
+
+This app maintains a file with Suricata rules. The app writes to it and Suricata
+reads from it. You need to make this file known to your Suricata installation by
+adding it to the rules configuration section in the `suricata.yaml` config file.
+Suricata won't pick up rule changes if you skip this step.
+
+Here is an example snippet to add to your Suricata config file:
+
+```
+/etc/suricata/suricata.yaml
+--------------------------------------------------------------------------------
+
+....
+
+default-rule-path: /var/lib/suricata/rules
+
+rule-files:
+  - suricata.rules
+  - threatbus.rules         # !! managed by suricata-threatbus
+
+....
+```
+
+In this example, we configure Suricata to read additional rules from a file
+called `threatbus.rules`, located in the default rule path
+`/var/lib/suricata/rules`.
+
+You need to provide the path of your custom rule file to this app, so it can
+modify the file contents when new indicators arrive. See also the `rules_file`
+config option in the `config.yaml.example` file.

--- a/apps/suricata/README.md
+++ b/apps/suricata/README.md
@@ -15,6 +15,10 @@ Make also sure that this app (e.g., user running this app) has the correct
 permissions to use the `suricatasc` command line utility and can read/write the
 rules file.
 
+Received rule updates are not applied instantaneously to minimize load on
+Suricata. Instead, users must configure the `reload_interval` (seconds) in the
+config file to enable periodic reloads for Suricata to pick up rule changes.
+
 ## Quick Start
 
 You can configure the app via a YAML configuration file. See

--- a/apps/suricata/config.yaml.example
+++ b/apps/suricata/config.yaml.example
@@ -1,0 +1,9 @@
+logging:
+  console: true
+  console_verbosity: DEBUG
+  file: true
+  file_verbosity: DEBUG
+  filename: suricata-threatbus.log
+
+threatbus: localhost:13370
+snapshot: 30

--- a/apps/suricata/config.yaml.example
+++ b/apps/suricata/config.yaml.example
@@ -7,3 +7,8 @@ logging:
 
 threatbus: localhost:13370
 snapshot: 30
+# The socket to use for connecting with Suricata.
+socket: /var/run/suricata/suricata-command.socket
+rules_file: /var/lib/suricata/rules/threatbus.rules
+# Interval in seconds to trigger `suricatasc -c ruleset-reload-nonblocking`
+reload_interval: 60

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -31,6 +31,7 @@ setup(
         "coloredlogs >= 14.0",
         "confuse",
         "pyzmq >= 19",
+        "parsuricata",
         "stix2 >= 2.1",
         "threatbus >= 2021.5.27",
     ],

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    author="Tenzir",
+    author_email="engineering@tenzir.com",
+    classifiers=[
+        # https://pypi.org/classifiers/
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
+        "Topic :: Security",
+        "Topic :: Software Development :: Object Brokering",
+        "Topic :: System :: Distributed Computing",
+    ],
+    description="A simple ZMQ app to connect to Threat Bus and ingest indicators as Suricata rules via `suricatasc`",
+    entry_points={
+        "console_scripts": ["suricata-threatbus=suricata_threatbus.suricata:main"]
+    },
+    include_package_data=True,
+    install_requires=[
+        "black >= 19.10b",
+        "coloredlogs >= 14.0",
+        "confuse",
+        "pyzmq >= 19",
+        "stix2 >= 2.1",
+        "threatbus >= 2021.5.27",
+    ],
+    keywords=[
+        "open source",
+        "Suricata",
+        "suricatasc",
+        "IDS rules",
+        "threatbus",
+        "Threat Bus",
+        "threat intelligence",
+        "TI",
+        "TI dissemination",
+    ],
+    license="BSD 3-clause",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    name="suricata-threatbus",
+    packages=["suricata_threatbus"],
+    python_requires=">=3.7",
+    setup_requires=["setuptools", "wheel"],
+    url="https://github.com/tenzir/threatbus",
+    version="2021.05.27",
+)

--- a/apps/suricata/suricata_threatbus/suricata.py
+++ b/apps/suricata/suricata_threatbus/suricata.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+
+import argparse
+import asyncio
+import atexit
+import coloredlogs
+import confuse
+import logging
+import signal
+from stix2 import parse
+import sys
+from threatbus.logger import setup as setup_logging_threatbus
+import zmq
+
+logger_name = "suricata-threatbus"
+logger = logging.getLogger(logger_name)
+# List of all running async tasks of the bridge.
+async_tasks = []
+# The p2p topic sent back by Threat Bus upon successful subscription.
+p2p_topic = None
+# Boolean flag indicating that the user has issued a SIGNAL (e.g., SIGTERM).
+user_exit = False
+
+### --------------------------- Application helpers ---------------------------
+
+
+def setup_logging_with_level(level: str):
+    """
+    Sets up a the global logger for console logging with the given loglevel.
+    @param level The loglevel to use, e.g., "DEBUG"
+    """
+    global logger
+    log_level = logging.getLevelName(level.upper())
+
+    fmt = "%(asctime)s %(levelname)-8s %(message)s"
+    colored_formatter = coloredlogs.ColoredFormatter(fmt)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(log_level)
+    if logger.level > log_level or logger.level == 0:
+        logger.setLevel(log_level)
+    handler.setFormatter(colored_formatter)
+    logger.addHandler(handler)
+
+
+def setup_logging_with_config(config: confuse.Subview):
+    """
+    Sets up the global logger as configured in the `config` object.
+    @param config The user-defined logging configuration
+    """
+    global logger
+    logger = setup_logging_threatbus(config, logger_name)
+
+
+def validate_config(config: confuse.Subview):
+    assert config, "config must not be None"
+    config["threatbus"].get(str)
+    config["snapshot"].get(int)
+
+
+async def cancel_async_tasks():
+    """
+    Cancels all async tasks.
+    """
+    global async_tasks
+    for task in async_tasks:
+        if task is not asyncio.current_task():
+            task.cancel()
+            del task
+    async_tasks = []
+    return await asyncio.gather(*async_tasks)
+
+
+async def stop_signal():
+    """
+    Implements Python's asyncio eventloop signal handler
+    https://docs.python.org/3/library/asyncio-eventloop.html
+    Cancels all running tasks and exits the app.
+    """
+    global user_exit
+    user_exit = True
+    await cancel_async_tasks()
+
+
+### --------------- ZeroMQ communication / management functions ---------------
+
+
+def send_manage_message(endpoint: str, action: dict, timeout: int = 5):
+    """
+    Sends a 'management' message, following the threatbus-zmq-app protocol to
+    either subscribe or unsubscribe this application to/from Threat Bus.
+    @param endpoint A host:port string to connect to via ZeroMQ
+    @param action The message to send as JSON
+    @param timeout The period after which the connection attempt is aborted
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.REQ)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.connect(f"tcp://{endpoint}")
+    socket.send_json(action)
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
+
+    reply = None
+    if poller.poll(timeout * 1000):
+        reply = socket.recv_json()
+    socket.close()
+    context.term()
+    return reply
+
+
+def reply_is_success(reply: dict):
+    """
+    Predicate to check if `reply` is a dict and contains the key-value pair
+    "status" = "success"
+    @param reply A python dict
+    @return True if the dict contains "status" = "success"
+    """
+    return (
+        reply
+        and type(reply) is dict
+        and reply.get("status", None)
+        and reply["status"] == "success"
+    )
+
+
+def subscribe(endpoint: str, topic: str, snapshot: int, timeout: int = 5):
+    """
+    Subscribes this app to Threat Bus for the given topic. Requests an optional
+    snapshot of historical indicators.
+    @param endpoint The ZMQ management endpoint of Threat Bus ('host:port')
+    @param topic The topic to subscribe to
+    @param snapshot An integer value to request n days of historical IoC items
+    @param timeout The period after which the connection attempt is aborted
+    """
+    global logger
+    logger.info(f"Subscribing to topic '{topic}'...")
+    action = {"action": "subscribe", "topic": topic, "snapshot": snapshot}
+    return send_manage_message(endpoint, action, timeout)
+
+
+def unsubscribe(endpoint: str, topic: str, timeout: int = 5):
+    """
+    Unsubscribes this app from Threat Bus for the given topic.
+    @param endpoint The ZMQ management endpoint of Threat Bus
+    @param topic The topic to unsubscribe from
+    @param timeout The period after which the connection attempt is aborted
+    """
+    global logger
+    logger.info(f"Unsubscribing from topic '{topic}' ...")
+    action = {"action": "unsubscribe", "topic": topic}
+    reply = send_manage_message(endpoint, action, timeout)
+    if not reply_is_success(reply):
+        logger.warning("Unsubscription failed")
+        return
+    logger.info("Unsubscription successful")
+
+
+async def heartbeat(endpoint: str, p2p_topic: str, interval: int = 5):
+    """
+    Sends heartbeats to Threat Bus periodically to check if the given p2p_topic
+    is still valid at the Threat Bus host. Cancels all async tasks of this app
+    when the heartbeat fails and stops the heartbeat.
+    @param endpoint The ZMQ management endpoint of Threat Bus
+    @param p2p_topic The topic string to include in the heartbeat
+    @param timeout The period after which the connection attempt is aborted
+    """
+    global logger
+    action = {"action": "heartbeat", "topic": p2p_topic}
+    while True:
+        reply = send_manage_message(endpoint, action, interval)
+        if not reply_is_success(reply):
+            logger.error("Subscription with Threat Bus host became invalid")
+            return await cancel_async_tasks()
+        await asyncio.sleep(interval)
+
+
+### --------------------------- The actual app logic ---------------------------
+
+
+async def start(zmq_endpoint: str, snapshot: int):
+    """
+    Starts the Suricata app.
+    @param zmq_endpoint The ZMQ management endpoint of Threat Bus ('host:port')
+    @param snapshot An integer value to request n days of historical IoC items
+    """
+    global logger, async_tasks, p2p_topic
+    # needs to be created inside the same eventloop where it is used
+    logger.debug(f"Calling Threat Bus management endpoint {zmq_endpoint}")
+    reply = subscribe(zmq_endpoint, "stix2/indicator", snapshot)
+    if not reply_is_success(reply):
+        logger.error("Subscription failed")
+        return
+    pub_endpoint = reply.get("pub_endpoint", None)
+    sub_endpoint = reply.get("sub_endpoint", None)
+    topic = reply.get("topic", None)
+    if not pub_endpoint or not sub_endpoint or not topic:
+        logger.error("Subscription failed")
+        return
+
+    logger.info(f"Subscription successful. New p2p_topic: {topic}")
+    if p2p_topic:
+        # The 'start' function is called as result of a restart
+        # Unsubscribe the old topic as soon as we get a working connection
+        logger.info("Cleaning up old p2p_topic subscription ...")
+        unsubscribe(zmq_endpoint, p2p_topic)
+        atexit.unregister(unsubscribe)
+    p2p_topic = topic
+    atexit.register(unsubscribe, zmq_endpoint, topic)
+
+    # Start a heartbeat task so we notice when the Threat Bus host goes away
+    async_tasks.append(
+        asyncio.create_task(heartbeat(zmq_endpoint, p2p_topic, interval=5))
+    )
+
+    # Start a receive task to retrieve real-time updates from Threat Bus
+    indicator_queue = asyncio.Queue()
+    async_tasks.append(
+        asyncio.create_task(receive(pub_endpoint, p2p_topic, indicator_queue))
+    )
+    async_tasks.append(asyncio.create_task(update_suricata(indicator_queue)))
+
+    loop = asyncio.get_event_loop()
+    for s in [signal.SIGHUP, signal.SIGTERM, signal.SIGINT]:
+        loop.add_signal_handler(s, lambda: asyncio.create_task(stop_signal()))
+    return await asyncio.gather(*async_tasks)
+
+
+async def receive(pub_endpoint: str, topic: str, indicator_queue: asyncio.Queue):
+    """
+    Starts a zmq subscriber on the given endpoint and listens for new messages
+    that are published on the given topic (zmq prefix matching). Depending on
+    the topic suffix, Indicators are enqueued to the indicator_queue.
+    @param pub_endpoint A host:port string to connect to via zmq
+    @param topic The topic prefix to subscribe to intelligence items
+    @param indicator_queue The queue to put arriving IoCs into
+    """
+    global logger
+    socket = zmq.Context().socket(zmq.SUB)
+    socket.connect(f"tcp://{pub_endpoint}")
+    socket.setsockopt(zmq.SUBSCRIBE, topic.encode())
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
+    logger.info(f"Receiving via ZMQ on topic {pub_endpoint}/{topic}")
+    while True:
+        socks = dict(poller.poll(timeout=100))  # Smaller timeouts increase CPU load
+        if socket in socks and socks[socket] == zmq.POLLIN:
+            try:
+                topic, msg = socket.recv().decode().split(" ", 1)
+            except Exception as e:
+                logger.error(f"Error decoding message: {e}")
+                continue
+            # The topic is suffixed with the message type. Use it for filtering
+            if not topic.endswith("indicator"):
+                logger.debug(f"Skipping unsupported message: {msg}")
+                continue
+            # Put the message into the queue for incoming intel items, so they
+            # can be processed asynchronously
+            await indicator_queue.put(msg)
+        else:
+            await asyncio.sleep(0.01)  # Free event loop for other tasks
+
+
+async def update_suricata(indicator_queue: asyncio.Queue):
+    """
+    Updates the Suricata `threatbus.rules` with the received STIX-2 Indicator.
+    @param indicator_queue The queue to receive IoCs from
+    """
+    while True:
+        msg = await indicator_queue.get()
+        indicator = parse(msg, allow_custom=True)
+        logger.debug(f"Got indicator from Threat Bus: {indicator}")
+        # Do something with it, e.g., check its type and then start operating on
+        # the timestamps, the STIX pattern, ...
+        indicator_queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", "-c", help="Path to a configuration file")
+    args = parser.parse_args()
+
+    # Note that you must use names without dashes, use underscores instead for
+    # `confuse` to work without errors.
+    # Confuse uses the configuration name to lookup environment variables, but
+    # it simply upper-cases that name. Dashes are not replaced properly. Using a
+    # dash in the configuration name makes it impossible to configure the
+    # APPNAMEDIR env variable to overwrite search paths, i.e., in systemd
+    # https://confit.readthedocs.io/en/latest/#search-paths
+    # https://github.com/beetbox/confuse/blob/v1.4.0/confuse/core.py#L555
+    config = confuse.Configuration("suricata_threatbus")
+    config.set_args(args)
+    if args.config:
+        config.set_file(args.config)
+
+    try:
+        validate_config(config)
+    except Exception as e:
+        sys.exit(ValueError(f"Invalid config: {e}"))
+
+    if config["logging"].get(dict):
+        setup_logging_with_config(config["logging"])
+    else:
+        setup_logging_with_level(config["loglevel"].get(str))
+
+    while True:
+        try:
+            asyncio.run(
+                start(
+                    config["threatbus"].get(),
+                    config["snapshot"].get(),
+                )
+            )
+        except (KeyboardInterrupt, SystemExit):
+            return
+        except asyncio.CancelledError:
+            if user_exit:
+                # Tasks were cancelled because the user stopped the app.
+                return
+            logger.info("Restarting Suricata app ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/suricata/suricata_threatbus/suricata.py
+++ b/apps/suricata/suricata_threatbus/suricata.py
@@ -10,7 +10,7 @@ from os.path import dirname, join
 from parsuricata import parse_rules
 import re
 from shlex import split as lexical_split
-from shutil import copy
+from shutil import move
 import signal
 from stix2 import parse
 import sys
@@ -194,6 +194,9 @@ async def start(
     Starts the Suricata app.
     @param zmq_endpoint The ZMQ management endpoint of Threat Bus ('host:port')
     @param snapshot An integer value to request n days of historical IoC items
+    @param socket The Suricata UNIX socket to connect with
+    @param rules_file The Threat Bus rules file maintained by this app
+    @param reload_interval The periodic interval to reload Threat Bus rules
     """
     global logger, async_tasks, p2p_topic
     # needs to be created inside the same eventloop where it is used
@@ -322,7 +325,7 @@ async def update_suricata_rules(indicator_queue: asyncio.Queue, rules_file: str)
                     new_rule += "\n"
                 tfile.write(new_rule)
         indicator_queue.task_done()
-        copy(tmp_file, rules_file)
+        move(tmp_file, rules_file)
         logger.debug(f"Updated Threat Bus rule file with {indicator.pattern}")
 
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds a new Python app that connects to Threat Bus via ZeroMQ and listens for STIX-2 indicators with `pattern_type == "suricata"`. Those indicators are then parsed and rule updates are pushed to a suricata rules file, which the user first must configure in their `suricata.yaml` config file.

The app support CUD in a very simplistic, file-based form. We use `suricatasc` to instruct Suricata via its UNIX control socket to re-read the rules from the app-maintained rules file in a configurable interval.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

For interactive testing:

- Read the README to prepare your local Suricata
- Start Suricata
- Start OpenCTI
- Start the Threat Bus OpenCTI connector
- Start Threat Bus
- Start the new app (this PR)
- Create new Suricata-typed indicators in OpenCTI (e.g., pattern = `alert http any any -> any any (msg: "Test444"; content:"example.com"; http_host; sid:772;)`
- Verify they are flushed to Suricata (e.g., `curl example.com` -> should generate an alert in your `eve.json`)
