### PR TITLE
Fix format of line protocol metrics syntax

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -13,10 +13,11 @@ Every entry has a category for which we use the following visual abbreviations:
 ## Unreleased
 
 - 🐞 The metrics value serialization in `pyvast-threatbus` contained spaces in
-  the fields of the measurements, which is not valid according to the line
-  protocol spec and caused the measurement to be rejected. This behavior was
-  fixed to ensure all fields are separated by commas.
-  [#112](https://github.com/tenzir/threatbus/pull/136)
+  the fields of the measurements, which is not valid according to the
+  [line protocol spec](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)
+  and caused the measurement to be rejected. We fixed the format to ensure all
+  fields are separated by commas.
+  [#136](https://github.com/tenzir/threatbus/pull/136)
 
 ## [2021.06.24]
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,7 +10,13 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🐞 The metrics value serialization in `pyvast-threatbus` contained spaces in
+  the fields of the measurements, which is not valid according to the line
+  protocol spec and caused the measurement to be rejected. This behavior was
+  fixed to ensure all fields are separated by commas.
+  [#112](https://github.com/tenzir/threatbus/pull/136)
 
 ## [2021.06.24]
 

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -262,16 +262,20 @@ async def write_metrics(every: int, to: str):
     @param to the filepath to write to
     """
     while True:
-        line = f"pyvast-threatbus,host={socket.gethostname()}"
+        line = f"pyvast-threatbus,host={socket.gethostname()} "
         start_length = len(line)
         for m in metrics:
             if not m.is_set:
                 continue
             if type(m) is Gauge or type(m) is InfiniteGauge:
-                line += f" {m.name}={m.value}"
+                if len(line) > start_length:
+                    line += ","
+                line += f"{m.name}={m.value}"
             if type(m) is Summary:
+                if len(line) > start_length:
+                    line += ","
                 line += (
-                    f" {m.name}_min={m.min},{m.name}_max={m.max},{m.name}_avg={m.avg}"
+                    f"{m.name}_min={m.min},{m.name}_max={m.max},{m.name}_avg={m.avg}"
                 )
             m.reset()
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The current implementation of the metrics value serialization includes spaces into the fields of the measurements, which is not valid according to the spec and will cause the measurement to be rejected. This PR changes this behaviour to ensure all fields are separated by commas.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Compare code and output to line protocol specification.