### PR TITLE
Release `suricata-threatbus` Docker image together with Threat Bus

### DIFF
--- a/.github/workflows/python-egg.yml
+++ b/.github/workflows/python-egg.yml
@@ -84,6 +84,13 @@ jobs:
         workdir: apps/stix-shifter
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Publish suricata-threatbus Docker Image
+      uses: elgohr/Publish-Docker-Github-Action@3.04
+      with:
+        name: tenzir/suricata-threatbus
+        workdir: apps/suricata
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   egg-release:
     name: Egg Release

--- a/apps/suricata/CHANGELOG.md
+++ b/apps/suricata/CHANGELOG.md
@@ -11,7 +11,11 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 We now release a pre-built Docker image for `suricata-threatbus` together
+  with our future Threat Bus releases.
+  [#137](https://github.com/tenzir/threatbus/pull/137)
 
 ## [2021.06.24]
 

--- a/apps/suricata/Dockerfile
+++ b/apps/suricata/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:buster-slim
+
+RUN apt-get -qq update && apt-get -qqy install \
+  python3-pip software-properties-common
+
+RUN pip3 install --upgrade pip
+
+WORKDIR /opt/tenzir/threatbus/suricata-threatbus
+COPY setup.py .
+COPY README.md .
+COPY suricata_threatbus suricata_threatbus
+RUN python3 -m pip install .
+
+RUN echo "Adding threatbus user" && useradd -m -d /home/threatbus --user-group threatbus
+RUN chown -R threatbus .
+USER threatbus:threatbus
+
+ENTRYPOINT ["suricata-threatbus"]
+CMD ["-h"]


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Add Dockerfile and add to release workflow.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Build and run the image.