### PR TITLE
Remove Docker entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental Features
 - 🐞 Bug Fixes
 
-<!-- ## Unreleased -->
-
-## [2021.06.24]
+## Unreleased
 
 - ⚠️ Threat Bus now uses [Dynaconf](https://github.com/rochacbruno/dynaconf) for
   configuration management. Configuration via a config file works exactly as it
@@ -23,6 +21,8 @@ Every entry has a category for which we use the following visual abbreviations:
   to be prefixed with `THREATBUS_` to be respected and always take precedence
   over values in config files.
   [#133](https://github.com/tenzir/threatbus/pull/133)
+
+## [2021.06.24]
 
 - ⚠️ The official [tenzir/threatbus](https://hub.docker.com/r/tenzir/threatbus)
   Docker image now uses Debian:Bullseye as

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,3 @@ RUN python3 -m pip install . && \
 COPY config* ./
 
 ENTRYPOINT ["threatbus"]
-CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ docker run tenzir/threatbus:latest --help
 docker run -p 47661:47661 -v $PWD/my-custom-config.yaml:/opt/tenzir/threatbus/my-custom-config.yaml tenzir/threatbus:latest -c my-custom-config.yaml
 ```
 
+Tip: Threat Bus checks for config files with default names. If you mount your
+config file to `/opt/tenzir/threatbus/config.yaml`, you can start the
+application without specifying the config file location with the `-c` parameter.
+
 ## Installation
 
 Install `threatbus` and all plugins that you require. Optionally, use a virtual

--- a/apps/stix-shifter/Dockerfile
+++ b/apps/stix-shifter/Dockerfile
@@ -16,4 +16,3 @@ RUN chown -R threatbus .
 USER threatbus:threatbus
 
 ENTRYPOINT ["stix-shifter-threatbus"]
-CMD ["-h"]

--- a/apps/suricata/Dockerfile
+++ b/apps/suricata/Dockerfile
@@ -16,4 +16,3 @@ RUN chown -R threatbus .
 USER threatbus:threatbus
 
 ENTRYPOINT ["suricata-threatbus"]
-CMD ["-h"]

--- a/apps/vast/Dockerfile
+++ b/apps/vast/Dockerfile
@@ -22,4 +22,3 @@ RUN chown -R threatbus .
 USER threatbus:threatbus
 
 ENTRYPOINT ["pyvast-threatbus"]
-CMD ["-h"]


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->
Allows Threat Bus to start in Docker without requiring the user to provide a command. Possible since we have Dynaconf.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Build the image and run it.