### PR TITLE
Threat Bus zmq apps use the wrong host name after connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The content and format of the `threatbus-zmq-app` plugin's subscription
+  success response has changed. Prior to this change, the plugin used to respond
+  with an endpoint in the `host:port` format, which contained a wrong hostname
+  (e.g., `0.0.0.0` instead of a publicly reachable topic).
+  From now on, the plugin returns only the ports for `pub` and `sub`
+  communication and leaves it to the subscribing app to connect with the right
+  host/IP.
+  [#140](https://github.com/tenzir/threatbus/pull/140)
+
 - ⚠️ Threat Bus now uses [Dynaconf](https://github.com/rochacbruno/dynaconf) for
   configuration management. Configuration via a config file works exactly as it
   has worked before. Users can provide a path to the config file using the `-c`

--- a/apps/stix-shifter/CHANGELOG.md
+++ b/apps/stix-shifter/CHANGELOG.md
@@ -19,8 +19,6 @@ Every entry has a category for which we use the following visual abbreviations:
   from PyPI.
   [#141](https://github.com/tenzir/threatbus/pull/141)
 
-## [2021.06.24]
-
 - 🐞 `stix-shifter-threatbus` now implements the new zmq management protocol of
   the `threatbus-zmq-app` plugin. The app now simply re-uses the Threat Bus
   hostname as it is configured in the users `config.yaml` and appends the port
@@ -40,6 +38,7 @@ Every entry has a category for which we use the following visual abbreviations:
   values in config files.
   [#133](https://github.com/tenzir/threatbus/pull/133)
 
+## [2021.06.24]
 
 - 🎁 `stix-shifter-threatbus` now comes with its own Dockerfile. Pre-built
   images are available on

--- a/apps/stix-shifter/CHANGELOG.md
+++ b/apps/stix-shifter/CHANGELOG.md
@@ -15,6 +15,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [2021.06.24]
 
+- 🐞 `stix-shifter-threatbus` now implements the new zmq management protocol of
+  the `threatbus-zmq-app` plugin. The app now simply re-uses the Threat Bus
+  hostname as it is configured in the users `config.yaml` and appends the port
+  specifications for `pub` and `sub` communication that it receives as part of
+  the subscription success response.
+  [#140](https://github.com/tenzir/threatbus/pull/140)
+
 - ⚠️ `stix-shifter-threatbus` now uses
   [Dynaconf](https://github.com/rochacbruno/dynaconf) for configuration
   management. Configuration via a config file works exactly as it has worked

--- a/apps/stix-shifter/stix_shifter_threatbus/shifter.py
+++ b/apps/stix-shifter/stix_shifter_threatbus/shifter.py
@@ -233,12 +233,15 @@ async def start(zmq_endpoint: str, snapshot: int, modules_config: dict):
     if not reply_is_success(reply):
         logger.error("Subscription failed")
         return
-    pub_endpoint = reply.get("pub_endpoint", None)
-    sub_endpoint = reply.get("sub_endpoint", None)
+    pub_port = reply.get("pub_port", None)
+    sub_port = reply.get("sub_port", None)
     topic = reply.get("topic", None)
-    if not pub_endpoint or not sub_endpoint or not topic:
+    if not pub_port or not sub_port or not topic:
         logger.error("Subscription failed")
         return
+    zmq_host = zmq_endpoint.split(:)[1]
+    pub_endpoint = f"{zmq_host}:{pub_port}"
+    sub_endpoint = f"{zmq_host}:{sub_port}"
 
     logger.info(f"Subscription successful. New p2p_topic: {topic}")
     if p2p_topic:

--- a/apps/suricata/CHANGELOG.md
+++ b/apps/suricata/CHANGELOG.md
@@ -13,6 +13,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 `suricata-threatbus` now implements the new zmq management protocol of the
+  `threatbus-zmq-app` plugin. The app now simply re-uses the Threat Bus hostname
+  as it is configured in the users `config.yaml` and appends the port
+  specifications for `pub` and `sub` communication that it receives as part of
+  the subscription success response.
+  [#140](https://github.com/tenzir/threatbus/pull/140)
+
 - 🎁 We now release a pre-built Docker image for `suricata-threatbus` together
   with our future Threat Bus releases.
   [#137](https://github.com/tenzir/threatbus/pull/137)

--- a/apps/suricata/CHANGELOG.md
+++ b/apps/suricata/CHANGELOG.md
@@ -29,8 +29,6 @@ Every entry has a category for which we use the following visual abbreviations:
   with our future Threat Bus releases.
   [#137](https://github.com/tenzir/threatbus/pull/137)
 
-## [2021.06.24]
-
 - ⚠️ `suricata-threatbus` now uses
   [Dynaconf](https://github.com/rochacbruno/dynaconf) for configuration
   management. Configuration via a config file works exactly as it has worked
@@ -41,6 +39,8 @@ Every entry has a category for which we use the following visual abbreviations:
   `.dotenv`. Env vars need to be prefixed with `SURICATA_THREATBUS_` to be
   respected and always take precedence over values in config files.
   [#133](https://github.com/tenzir/threatbus/pull/133)
+
+## [2021.06.24]
 
 - 🎁 `suricata-threatbus` has come to life. This stand-alone application
   connects to Threat Bus via ZeroMQ and bridges the gap between Threat Bus and

--- a/apps/suricata/suricata_threatbus/suricata.py
+++ b/apps/suricata/suricata_threatbus/suricata.py
@@ -213,12 +213,15 @@ async def start(
     if not reply_is_success(reply):
         logger.error("Subscription failed")
         return
-    pub_endpoint = reply.get("pub_endpoint", None)
-    sub_endpoint = reply.get("sub_endpoint", None)
+    pub_port = reply.get("pub_port", None)
+    sub_port = reply.get("sub_port", None)
     topic = reply.get("topic", None)
-    if not pub_endpoint or not sub_endpoint or not topic:
+    if not pub_port or not sub_port or not topic:
         logger.error("Subscription failed")
         return
+    zmq_host = zmq_endpoint.split(:)[1]
+    pub_endpoint = f"{zmq_host}:{pub_port}"
+    sub_endpoint = f"{zmq_host}:{sub_port}"
 
     logger.info(f"Subscription successful. New p2p_topic: {topic}")
     if p2p_topic:

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 `pyvast-threatbus` now implements the new zmq management protocol of the
+  `threatbus-zmq-app` plugin. The app now simply re-uses the Threat Bus hostname
+  as it is configured in the users `config.yaml` and appends the port
+  specifications for `pub` and `sub` communication that it receives as part of
+  the subscription success response.
+  [#140](https://github.com/tenzir/threatbus/pull/140)
+
 - 🐞 The metrics value serialization in `pyvast-threatbus` contained spaces in
   the fields of the measurements, which is not valid according to the
   [line protocol spec](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/)

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -175,12 +175,16 @@ async def start(
     if not reply_is_success(reply):
         logger.error("Subscription failed")
         return
-    pub_endpoint = reply.get("pub_endpoint", None)
-    sub_endpoint = reply.get("sub_endpoint", None)
+    pub_port = reply.get("pub_port", None)
+    sub_port = reply.get("sub_port", None)
     topic = reply.get("topic", None)
-    if not pub_endpoint or not sub_endpoint or not topic:
+    if not pub_port or not sub_port or not topic:
         logger.error("Subscription failed")
         return
+    zmq_host = zmq_endpoint.split(:)[1]
+    pub_endpoint = f"{zmq_host}:{pub_port}"
+    sub_endpoint = f"{zmq_host}:{sub_port}"
+
     logger.info(f"Subscription successful. New p2p_topic: {topic}")
     if p2p_topic:
         # The 'start' function is called as result of a restart

--- a/apps/zmq-app-template/zmq_app_template/template.py
+++ b/apps/zmq-app-template/zmq_app_template/template.py
@@ -196,12 +196,15 @@ async def start(zmq_endpoint: str, snapshot: int):
     if not reply_is_success(reply):
         logger.error("Subscription failed")
         return
-    pub_endpoint = reply.get("pub_endpoint", None)
-    sub_endpoint = reply.get("sub_endpoint", None)
+    pub_port = reply.get("pub_port", None)
+    sub_port = reply.get("sub_port", None)
     topic = reply.get("topic", None)
-    if not pub_endpoint or not sub_endpoint or not topic:
+    if not pub_port or not sub_port or not topic:
         logger.error("Subscription failed")
         return
+    zmq_host = zmq_endpoint.split(:)[1]
+    pub_endpoint = f"{zmq_host}:{pub_port}"
+    sub_endpoint = f"{zmq_host}:{sub_port}"
 
     logger.info(f"Subscription successful. New p2p_topic: {topic}")
     if p2p_topic:

--- a/plugins/apps/threatbus_zmq_app/README.md
+++ b/plugins/apps/threatbus_zmq_app/README.md
@@ -79,18 +79,18 @@ In response, the app will either receive a `success` or `error` response.
   ```
   {
     "topic": <P2P_TOPIC>,
-    "pub_endpoint": "127.0.0.1:13371",
-    "sub_endpoint": "127.0.0.1:13372",
+    "pub_port": 13371,
+    "sub_port": 13372,
     "status": "success",
   }
   ```
 
-  The `pub_endpoint` and `sub_endpoint` of the reply provide the endpoints that
-  an app should connect with to participate in the pub/sub message exchange.
-  The app can access these endpoints following the
+  The `pub_port` and `sub_port` of the reply provide the port that an app should
+  connect with to participate in the pub/sub message exchange. A connecting app
+  can access these ports following the
   [ZeroMQ Pub/Sub](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/pubsub.html)
-  pattern. The plugin will publish messages on the `pub_endpoint` and accept
-  messages on the `sub_endpoint`.
+  pattern. The plugin will publish messages on the `pub_port` and accept
+  messages on the `sub_port`.
 
   The `topic` field of the response contains a unique topic for the client. That
   topic _must_ be used to receive messages. The unique topic is a 32 characters

--- a/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/plugin.py
+++ b/plugins/apps/threatbus_zmq_app/threatbus_zmq_app/plugin.py
@@ -63,8 +63,6 @@ class SubscriptionManager(threatbus.StoppableWorker):
         context = zmq.Context()
         socket = context.socket(zmq.REP)  # REP socket for point-to-point reply
         socket.bind(f"tcp://{self.zmq_config.host}:{self.zmq_config.manage}")
-        pub_endpoint = f"{self.zmq_config.host}:{self.zmq_config.pub}"
-        sub_endpoint = f"{self.zmq_config.host}:{self.zmq_config.sub}"
 
         poller = zmq.Poller()
         poller.register(socket, zmq.POLLIN)
@@ -108,8 +106,8 @@ class SubscriptionManager(threatbus.StoppableWorker):
                         socket.send_json(
                             {
                                 "topic": p2p_topic,
-                                "pub_endpoint": pub_endpoint,
-                                "sub_endpoint": sub_endpoint,
+                                "pub_port": self.zmq_config.pub,
+                                "sub_port": self.zmq_config.sub,
                                 "status": "success",
                             }
                         )

--- a/tests/integration/test_zmq_app_management.py
+++ b/tests/integration/test_zmq_app_management.py
@@ -130,8 +130,8 @@ class TestMessageRoundtrip(unittest.TestCase):
         self.assertTrue(type(reply) is dict)
         self.assertEquals(reply["status"], "success")
         self.assertIsNotNone(reply["topic"])
-        self.assertEquals(reply["pub_endpoint"], "127.0.0.1:13371")
-        self.assertEquals(reply["sub_endpoint"], "127.0.0.1:13372")
+        self.assertEquals(reply["pub_port"], 13371)
+        self.assertEquals(reply["sub_port"], 13372)
 
         p2p_topic = reply["topic"]  # needed for heartbeat and unsubscription
         self.valid_heartbeat["topic"] = p2p_topic


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Prior to this change, Threat Bus (the `zmq-app` plugin) returned a wrong  `host:port` tuple to zmq apps. It used to send it's own bind IP address, which is not the same as the IP known to the outside world. Now it only sends the ports for pub/sub and leaves it to the apps to bind to the correct endpoint. 

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Run the integration test.
For interactive testing, run all ZMQ apps individually. 