### PR TITLE
Use FQDN in pyvast-threatbus metrics

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ Metrics sent by `pyvast-threatbus` used the short hostname as given by
+  `socket.gethostname()`. This has been changed to use `socket.getfqdn()`.
+  [#144](https://github.com/tenzir/threatbus/pull/144)
+
 - ⚠️ The Dockerfile of `pyvast-threatbus` has moved to the repository toplevel
   and now installs Threat Bus from source. This way, the Docker build always
   uses the `latest` Threat Bus sources, instead of the latest version from PyPI.

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -260,7 +260,7 @@ async def write_metrics(every: int, to: str):
     @param to the filepath to write to
     """
     while True:
-        line = f"pyvast-threatbus,host={socket.gethostname()} "
+        line = f"pyvast-threatbus,host={socket.getfqdn()} "
         start_length = len(line)
         for m in metrics:
             if not m.is_set:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR changes the metrics submitted by `pyvast-threatbus` to use the FQDN of the submitting system instead of the short hostname.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Confirm that this change makes sense and is not overly specific.