### PR TITLE
Start measurement of query time metric w/ actual query

### DIFF
--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The metric for indicator query time now only reflects the actual time spent
+  querying VAST and does not regard unstarted VAST queries any longer.
+  [#145](https://github.com/tenzir/threatbus/pull/145)
+
 - ⚠️ Metrics sent by `pyvast-threatbus` used the short hostname as given by
   `socket.gethostname()`. This has been changed to use `socket.getfqdn()`.
   [#144](https://github.com/tenzir/threatbus/pull/144)

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -339,13 +339,13 @@ async def retro_match_vast(
     @param indicator The STIX-2 Indicator to query VAST for
     @param sightings_queue The queue to put new sightings into
     """
-    start = time.time()
     query = indicator_to_vast_query(indicator)
     if not query:
         g_retro_match_backlog.dec()
         return
     global logger, max_open_tasks
     async with max_open_tasks:
+        start = time.time()
         vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
         kwargs = {}
         if retro_match_max_events > 0:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->
Start the measurement of the query time metric together with the actual indicator. This way, we don't skew the metric with indicators that cannot be processed due to user settings for max-background tasks.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
n/t