### PR TITLE
Pin version 2.x of stix2 package

### DIFF
--- a/apps/stix-shifter/setup.py
+++ b/apps/stix-shifter/setup.py
@@ -33,7 +33,7 @@ setup(
         "dynaconf >= 3.1.4",
         "python-dateutil",
         "pyzmq >= 19",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "stix-shifter >= 3.4.2",
         "stix-shifter-utils >= 3.4.2",
         "threatbus >= 2021.5.27",

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -31,7 +31,7 @@ setup(
         "dynaconf >= 3.1.4",
         "pyzmq >= 19",
         "parsuricata",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -32,7 +32,7 @@ setup(
         "python-dateutil",
         "pyzmq >= 19",
         "pyvast >= 2020.10.29",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/apps/zmq-app-template/setup.py
+++ b/apps/zmq-app-template/setup.py
@@ -30,7 +30,7 @@ setup(
         "black >= 19.10b",
         "dynaconf >= 3.1.4",
         "pyzmq >= 19",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable indicators to be submitted to CIFv3 in real-time",
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
     install_requires=[
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
         "cifsdk > 3.0.0rc4, < 4.0",
     ],

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -27,7 +27,7 @@ setup(
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
         "pymisp >= 2.4.120",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with Zeek network monitor.",
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
     install_requires=[
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/apps/threatbus_zmq_app/setup.py
+++ b/plugins/apps/threatbus_zmq_app/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "pyzmq>=19",
         "python-dateutil>=2.8.1",
-        "stix2>=2.1",
+        "stix2>=2.1,<3.0",
         "threatbus>=2021.5.27",
     ],
     keywords=[

--- a/plugins/backbones/file_benchmark/setup.py
+++ b/plugins/backbones/file_benchmark/setup.py
@@ -23,7 +23,7 @@ setup(
     description="A benchmark backbone for threatbus, that reads a file and provisions its contents.",
     entry_points={"threatbus.backbone": ["file_benchmark = file_benchmark.plugin"]},
     install_requires=[
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.2.24",
     ],
     keywords=["threatbus", "plugin"],

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -23,7 +23,7 @@ setup(
     description="A simplistic in-memory backbone for threatbus.",
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
     install_requires=[
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pika >= 1.1.0",
         "retry",
-        "stix2 >= 2.1",
+        "stix2 >= 2.1, < 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ dynaconf>=3.1.4
 pluggy>=0.13
 python-dateutil>=2.8.1
 stix2-patterns == 1.3.0
-stix2>=2.1
+stix2>=2.1,<3.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "pluggy>=0.13",
         "python-dateutil>=2.8.1",
         "stix2-patterns == 1.3.0",
-        "stix2>=2.1",
+        "stix2>=2.1,<3.0",
     ],
     keywords=[
         "threatbus",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Version 3.0.0 introduced some breaking changes that cause our unit tests to fail with errors like this:

    Traceback (most recent call last):
      File "/__w/threatbus/threatbus/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py", line 174, in test_valid_stix_sighting
        misp_sighting = stix2_sighting_to_misp(self.sighting)
      File "/__w/threatbus/threatbus/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py", line 329, in stix2_sighting_to_misp
        if "x_threatbus_source" in sighting.object_properties():
      File "/usr/local/lib/python3.9/dist-packages/stix2/base.py", line 269, in __getattr__
        raise AttributeError(
    AttributeError: 'Sighting' object has no attribute 'object_properties'
