### PR TITLE
Add support for VAST live matching to threatbus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 - ⚡️ The `threatbus-zmq-app` package has been renamed to `threatbus-zmq`, to
   address some limitations in the configuration framework.
+  [#157](https://github.com/tenzir/threatbus/pull/157)
 
 ## [2021.07.29]
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
+## Unreleased
+
+- 🎁 Live matching with VAST works again!
+  [#156](https://github.com/tenzir/threatbus/pull/156)
+
 ## [2021.07.29]
 
 - ⚠️ The metric for indicator query time now only reflects the actual time spent

--- a/apps/vast/pyvast_threatbus/message_mapping.py
+++ b/apps/vast/pyvast_threatbus/message_mapping.py
@@ -4,6 +4,10 @@ from stix2 import Indicator, Sighting
 from threatbus.data import ThreatBusSTIX2Constants
 from threatbus.stix2_helpers import is_point_equality_ioc, split_object_path_and_value
 from typing import Tuple, Union
+import logging
+
+logger_name = "pyvast-threatbus"
+logger = logging.getLogger(logger_name)
 
 vast_ioc_type_map = {
     "ipv4-addr:value": "ip",
@@ -12,7 +16,7 @@ vast_ioc_type_map = {
     "url:value": "url",
 }
 
-threatbus_reference = "threatbus__"
+THREATBUS_REFERENCE = "threatbus__"
 
 
 def vast_escape_str(val: str):
@@ -36,7 +40,7 @@ def get_vast_type_and_value(pattern_str: str) -> Union[Tuple[str, str], None]:
     return vast_type, ioc_value
 
 
-def indicator_to_vast_matcher_ioc(indicator: Indicator) -> Union[str, None]:
+def indicator_to_vast_matcher_ioc(indicator: Indicator) -> Union[dict, None]:
     """
     Maps a STIX-2 Indicator to a VAST compatible IoC format (JSON), so that a
     VAST matcher can ingest it.
@@ -51,13 +55,11 @@ def indicator_to_vast_matcher_ioc(indicator: Indicator) -> Union[str, None]:
         return None
     (vast_type, ioc_value) = type_and_value
 
-    return json.dumps(
-        {
-            "value": ioc_value,
-            "type": vast_type,
-            "reference": f"{threatbus_reference}{indicator.id}",
-        }
-    )
+    return {
+        "value": ioc_value,
+        "type": vast_type,
+        "reference": f"{threatbus_reference}{indicator.id}",
+    }
 
 
 def indicator_to_vast_query(indicator: Indicator) -> Union[str, None]:
@@ -121,23 +123,33 @@ def matcher_result_to_sighting(matcher_result: str) -> Union[Sighting, None]:
     @return a valid STIX-2 Sighting that references the IoC from the VAST
         matcher or None
     """
+    global logger
     if type(matcher_result) is not str:
         return None
     try:
         dct = json.loads(matcher_result)
-        ts = dct.get("ts", None)
+        ts = dct.get("event").get("ts")
         if type(ts) is str:
             ts = dateutil_parser.parse(ts)
-    except Exception:
+    except Exception as e:
+        logger.error(f"exception: {e}")
         return None
-    ref = dct.get("reference", "")
-    context = dct.get("context", {})
-    ioc_value = dct.get("value", "")
-    # ref = threatbus__indicator--46b3f973-5c03-41fc-9efe-49598a267a35
-    ref_len = len(threatbus_reference) + len("indicator--") + 36
-    if not ts or not ref or not len(ref) == ref_len:
+    ref = dct.get("indicator").get("context")
+    ioc_value = dct["indicator"]["value"]
+    # +36 for the uuid
+    # +2 for the double quotes
+    ref_len = len(THREATBUS_REFERENCE) + len("indicator--") + 36 + 2
+    if not ts:
+        logger.error("not ts")
         return None
-    ref = ref[len(threatbus_reference) :]
+    if not ref:
+        logger.error("not ref")
+        return None
+    if not len(ref) == ref_len:
+        logger.error(f"not len: {len(ref)} vs. {ref_len}")
+        return None
+    ref = ref[len(THREATBUS_REFERENCE) + 1 : -1]
+    context = {}
     context["source"] = "VAST"
     return Sighting(
         last_seen=ts,

--- a/apps/vast/pyvast_threatbus/pyvast_threatbus.py
+++ b/apps/vast/pyvast_threatbus/pyvast_threatbus.py
@@ -89,6 +89,12 @@ def validate_config(config: Settings):
         Validator("metrics.filename", default="metrics.log"),
         Validator("metrics.interval", is_type_of=int, default=10),
         Validator("live_match", is_type_of=bool, default=False),
+        Validator(
+            "matcher_name",
+            is_type_of=str,
+            when=Validator("live_match", eq=True),
+            required=True,
+        ),
         Validator("retro_match", is_type_of=bool, default=True),
         Validator("snapshot", is_type_of=int, default=30),
         Validator("retro_match_max_events", is_type_of=int, default=0),
@@ -385,7 +391,7 @@ async def ingest_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indic
     @param vast_endpoint The endpoint of a running vast node ('host:port')
     @param indicator The STIX-2 Indicator to query VAST for
     """
-    global logger
+    global logger, matcher_name
     vast_ioc = indicator_to_vast_matcher_ioc(indicator)
     if not vast_ioc:
         logger.error(
@@ -393,7 +399,11 @@ async def ingest_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indic
         )
         return
     vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-    proc = await vast.import_(type="intel.indicator").json().exec(stdin=vast_ioc)
+    proc = (
+        await vast.matcher()
+        .add(matcher_name, vast_ioc["value"], vast_ioc["reference"])
+        .exec()
+    )
     await proc.wait()
     logger.debug(f"Ingested indicator for VAST live matching: {indicator}")
 
@@ -413,8 +423,7 @@ async def remove_vast_ioc(vast_binary: str, vast_endpoint: str, indicator: Indic
         return None
     (vast_type, ioc_value) = type_and_value
     vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-    # TODO pass matcher_name once VAST supports more fine-grained deletion
-    await vast.matcher().intel().remove(ioc_value, vast_type).exec()
+    await vast.matcher().remove(matcher_name, ioc_value).exec()
     logger.debug(f"Removed indicator from VAST live matching: {indicator}")
 
 
@@ -494,12 +503,10 @@ async def live_match_vast(
     @param vast_binary The VAST binary command to use with PyVAST
     @param vast_endpoint The endpoint of a running VAST node
     @param sightings_queue The queue to put new sightings into
-    @param retro_match Boolean flag to use retro-matching over live-matching
     """
     global logger, matcher_name
     vast = VAST(binary=vast_binary, endpoint=vast_endpoint, logger=logger)
-    matcher_name = "threatbus-" + "".join(random.choice(letters) for i in range(10))
-    proc = await vast.matcher().start(name=matcher_name).exec()
+    proc = await vast.matcher().attach().json(matcher_name).exec()
     # returncode is None as long as the process did not terminate yet
     while proc.returncode is None:
         data = await proc.stdout.readline()
@@ -514,6 +521,7 @@ async def live_match_vast(
             logger.error(f"Cannot parse sighting-output from VAST: {vast_sighting}")
             continue
         g_live_matcher_sightings.inc()
+        logger.info(f"Got a new sighting from VAST")
         await sightings_queue.put(sighting)
     stderr = await proc.stderr.read()
     if stderr:
@@ -765,6 +773,8 @@ async def heartbeat(endpoint: str, p2p_topic: str, interval: int = 5):
 
 
 def main():
+    global matcher_name
+
     ## Default list of settings files for Dynaconf to parse.
     settings_files = ["config.yaml", "config.yml"]
     parser = argparse.ArgumentParser()
@@ -788,6 +798,10 @@ def main():
         sys.exit(ValueError(f"Invalid config: {e}"))
 
     setup_logging_with_config(config.logging)
+
+    # TODO: Pass matcher name as an argument instead of global var
+    if config.live_match:
+        matcher_name = config.matcher_name
 
     while True:
         try:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Support for VAST live matching was broken due to some syntax adjustments introduced with the recent matcher rewrite.

This PR reintroduces live matching support by slightly adjusting the way we interact with the matcher from Threat Bus.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
