### PR TITLE
Correctly validate 'apps.misp.api.*' config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Every entry has a category for which we use the following visual abbreviations:
   address some limitations in the configuration framework.
   [#157](https://github.com/tenzir/threatbus/pull/157)
 
+- 🐞 Fixed config validation for the 'apps.misp.api' setting.
+  [#161](https://github.com/tenzir/threatbus/pull/161)
+
 ## [2021.07.29]
 
 - 🐞 Threatbus now only attempts to load plugins that are explicitly

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -42,7 +42,7 @@ plugins:
       module_namespace: Tenzir
     # Requires the 'threatbus-misp' package to be installed
     misp:
-      api:                       # Optional
+      api:                       # Optional. If present, all of 'host', 'ssl', 'key' are required.
         host: https://localhost
         ssl: false
         key: MISP_API_KEY

--- a/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
@@ -222,16 +222,23 @@ def config_validators() -> List[Validator]:
             "operations": "Either configure the MISP plugin to use ZeroMQ or Kafka, but not both."
         },
     )
+    api_is_present = Validator(f"plugins.apps.{plugin_name}.api", required=True)
     return [
         Validator(
             f"plugins.apps.{plugin_name}.filter",
             is_type_of=list,
             default=[],
         ),
+        # TODO
         Validator(
-            f"plugins.apps.{plugin_name}.api",
-            is_type_of=dict,
-            default={},
+            f"plugins.apps.{plugin_name}.api.host",
+            f"plugins.apps.{plugin_name}.api.ssl",
+            f"plugins.apps.{plugin_name}.api.key",
+            when=Validator(f"plugins.apps.{plugin_name}.api", must_exist=True),
+            required=True,
+            messages={
+                "must_exist_true": "All of 'api.host', 'api.ssl', and 'api.key' must be defined when the 'api' key exists"
+            },
         ),
         zmq_kafka_mut_exclusive_validator,
         zmq_validator,

--- a/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/plugin.py
@@ -222,14 +222,13 @@ def config_validators() -> List[Validator]:
             "operations": "Either configure the MISP plugin to use ZeroMQ or Kafka, but not both."
         },
     )
-    api_is_present = Validator(f"plugins.apps.{plugin_name}.api", required=True)
     return [
         Validator(
             f"plugins.apps.{plugin_name}.filter",
             is_type_of=list,
             default=[],
         ),
-        # TODO
+        # TODO: Allow default values for 'host' and 'ssl'.
         Validator(
             f"plugins.apps.{plugin_name}.api.host",
             f"plugins.apps.{plugin_name}.api.ssl",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The 'apps.misp.api' key is optional, but the code used to assume
that if it is present, then all three of the subkeys 'api.host',
'api.ssl' and 'api.key' are also present.

We now validate that this is indeed the case.

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try providing an invalid MISP config and verify that threatbus doesn't start and doesn't crash with an unhandled exception.
<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
