### PR TITLE
Unpin stix2 and fix breaking changes

### DIFF
--- a/apps/stix-shifter/setup.py
+++ b/apps/stix-shifter/setup.py
@@ -33,7 +33,7 @@ setup(
         "dynaconf >= 3.1.4",
         "python-dateutil",
         "pyzmq >= 19",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "stix-shifter >= 3.4.2",
         "stix-shifter-utils >= 3.4.2",
         "threatbus >= 2021.5.27",

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -31,7 +31,7 @@ setup(
         "dynaconf >= 3.1.4",
         "pyzmq >= 19",
         "parsuricata",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/apps/suricata/suricata_threatbus/suricata.py
+++ b/apps/suricata/suricata_threatbus/suricata.py
@@ -325,8 +325,7 @@ async def update_suricata_rules(indicator_queue: asyncio.Queue, rules_file: str)
                     continue
                 tfile.write(rule)
             if (
-                ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value
-                not in indicator.object_properties()
+                ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value not in indicator
                 or indicator.x_threatbus_update != Operation.REMOVE.value
             ):
                 # Not a remove operation - append the new Suricata rule.

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -32,7 +32,7 @@ setup(
         "python-dateutil",
         "pyzmq >= 19",
         "pyvast >= 2020.10.29",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/apps/vast/vast_threatbus/test_message_mapping.py
+++ b/apps/vast/vast_threatbus/test_message_mapping.py
@@ -136,7 +136,7 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(parsed_sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-            in parsed_sighting.object_properties()
+            in parsed_sighting
         )
         expected_context = json.loads(self.valid_query_result)
         expected_context["source"] = "VAST"
@@ -160,7 +160,7 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(parsed_sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-            in parsed_sighting.object_properties()
+            in parsed_sighting
         )
         expected_context = {"source": "VAST"}
         self.assertEqual(parsed_sighting.x_threatbus_sighting_context, expected_context)

--- a/apps/vast/vast_threatbus/vast_threatbus.py
+++ b/apps/vast/vast_threatbus/vast_threatbus.py
@@ -463,8 +463,7 @@ async def match_intel(
             )
             continue
         if (
-            ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value
-            in indicator.object_properties()
+            ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value in indicator
             and indicator.x_threatbus_update == Operation.REMOVE.value
         ):
             g_iocs_removed.inc()
@@ -603,7 +602,7 @@ async def report_sightings(
             context = (
                 sighting.x_threatbus_sighting_context
                 if ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-                in sighting.object_properties()
+                in sighting
                 else None
             )
             if not context:
@@ -634,8 +633,7 @@ async def transform_context(sighting: Sighting, transform_cmd: str) -> Sighting:
     """
     context = (
         sighting.x_threatbus_sighting_context
-        if ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-        in sighting.object_properties()
+        if ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value in sighting
         else None
     )
     if not context:
@@ -645,8 +643,7 @@ async def transform_context(sighting: Sighting, transform_cmd: str) -> Sighting:
         return
     indicator = (
         sighting.x_threatbus_indicator
-        if ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value
-        in sighting.object_properties()
+        if ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value in sighting
         else None
     )
     if indicator:
@@ -655,8 +652,7 @@ async def transform_context(sighting: Sighting, transform_cmd: str) -> Sighting:
         # try to find the indicator value instead
         ioc_value = (
             sighting.x_threatbus_indicator_value
-            if ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR_VALUE.value
-            in sighting.object_properties()
+            if ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR_VALUE.value in sighting
             else None
         )
     if not ioc_value:

--- a/apps/zmq-app-template/setup.py
+++ b/apps/zmq-app-template/setup.py
@@ -30,7 +30,7 @@ setup(
         "black >= 19.10b",
         "dynaconf >= 3.1.4",
         "pyzmq >= 19",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable indicators to be submitted to CIFv3 in real-time",
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
     install_requires=[
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
         "cifsdk > 3.0.0rc4, < 4.0",
     ],

--- a/plugins/apps/threatbus_cif3/threatbus_cif3/message_mapping.py
+++ b/plugins/apps/threatbus_cif3/threatbus_cif3/message_mapping.py
@@ -34,10 +34,7 @@ def map_to_cif(
     if not indicator or type(indicator) is not Indicator:
         logger.debug(f"Expected STIX-2 indicator, discarding {indicator}")
         return None
-    if (
-        ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value
-        in indicator.object_properties()
-    ):
+    if ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value in indicator:
         logger.debug(
             f"CIFv3 only supports adding indicators, not deleting / editing. Discardig {indicator}"
         )

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -27,7 +27,7 @@ setup(
     entry_points={"threatbus.app": ["misp = threatbus_misp.plugin"]},
     install_requires=[
         "pymisp >= 2.4.120",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},

--- a/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
@@ -326,7 +326,7 @@ def stix2_sighting_to_misp(sighting: Sighting):
 
     misp_sighting = pymisp.MISPSighting()
     source = None
-    if "x_threatbus_source" in sighting.object_properties():
+    if "x_threatbus_source" in sighting:
         source = str(sighting.x_threatbus_source)
     misp_sighting.from_dict(
         id=misp_id(sighting.sighting_of_ref),

--- a/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
@@ -161,7 +161,7 @@ class TestMessageMapping(unittest.TestCase):
             indicator.pattern, f"[domain-name:value = '{self.domain_ioc}']"
         )
         # test that no custom properties are set
-        for prop in indicator.object_properties():
+        for prop in indicator:
             self.assertTrue(not prop.startswith("x_threatbus_"))
 
     def test_valid_misp_attribute_removal(self):

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -26,7 +26,7 @@ setup(
     description="A plugin to enable threatbus communication with Zeek network monitor.",
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
     install_requires=[
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/apps/threatbus_zeek/threatbus_zeek/message_mapping.py
+++ b/plugins/apps/threatbus_zeek/threatbus_zeek/message_mapping.py
@@ -129,8 +129,7 @@ def map_indicator_to_broker_event(
 
     operation = "ADD"  ## Zeek operation to add a new Intel item
     if (
-        ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value
-        in indicator.object_properties()
+        ThreatBusSTIX2Constants.X_THREATBUS_UPDATE.value in indicator
         and indicator.x_threatbus_update == Operation.REMOVE.value
     ):
         operation = "REMOVE"

--- a/plugins/apps/threatbus_zeek/threatbus_zeek/test_message_mapping.py
+++ b/plugins/apps/threatbus_zeek/threatbus_zeek/test_message_mapping.py
@@ -150,8 +150,7 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(sighting.last_seen, self.ts)
         self.assertEqual(sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
-            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-            in sighting.object_properties()
+            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value in sighting
         )
         self.assertEqual(sighting.x_threatbus_sighting_context, context)
 
@@ -164,8 +163,7 @@ class TestMessageMapping(unittest.TestCase):
         self.assertEqual(sighting.last_seen, self.ts)
         self.assertEqual(sighting.sighting_of_ref, self.indicator_id)
         self.assertTrue(
-            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-            in sighting.object_properties()
+            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value in sighting
         )
         self.assertEqual(sighting.x_threatbus_sighting_context, context)
 

--- a/plugins/backbones/file_benchmark/setup.py
+++ b/plugins/backbones/file_benchmark/setup.py
@@ -23,7 +23,7 @@ setup(
     description="A benchmark backbone for threatbus, that reads a file and provisions its contents.",
     entry_points={"threatbus.backbone": ["file_benchmark = file_benchmark.plugin"]},
     install_requires=[
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.2.24",
     ],
     keywords=["threatbus", "plugin"],

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -23,7 +23,7 @@ setup(
     description="A simplistic in-memory backbone for threatbus.",
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
     install_requires=[
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pika >= 1.1.0",
         "retry",
-        "stix2 >= 2.1, < 3.0",
+        "stix2 >= 3.0",
         "threatbus >= 2021.5.27",
     ],
     keywords=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ dynaconf>=3.1.4
 pluggy>=0.13
 python-dateutil>=2.8.1
 stix2-patterns == 1.3.0
-stix2>=2.1,<3.0
+stix2>=3.0

--- a/tests/integration/test_zeek_app.py
+++ b/tests/integration/test_zeek_app.py
@@ -124,8 +124,7 @@ class TestZeekSightingReports(unittest.TestCase):
         self.assertIsNotNone(sighting)
         self.assertEqual(sighting.sighting_of_ref, ioc_id)
         self.assertTrue(
-            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value
-            in sighting.object_properties()
+            ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value in sighting
         )
         self.assertEqual(sighting.x_threatbus_sighting_context, {"noisy": False})
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The `StixBase::object_properties()` method [was removed](https://github.com/oasis-open/cti-python-stix2/commit/2cda97cf5e51403c43a96ceb9073afab7706638a) in stix 3.0 on charges of being obsolete, breaking our code.

This PR removes the calls to `object_properties()` analogous to how it was done in the linked upstream PR, and bumps the minimum dependency version to 3.0 since making these changes will break compatibility with stix 2.x,

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
