### PR TITLE
Update codebase for pluggy 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental Features
 - 🐞 Bug Fixes
 
+## Unreleased
+
+- ⚠️  `threatbus` now depends on version 1.0 of `pluggy`.
+
 ## [2021.08.26]
 
 - ⚡️ The `threatbus-zmq-app` package has been renamed to `threatbus-zmq`, to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black>=19.10b
 coloredlogs>=10.0
 dynaconf>=3.1.4
-pluggy>=0.13,<1.0
+pluggy>=1.0
 python-dateutil>=2.8.1
 stix2-patterns == 1.3.0
 stix2>=3.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "black>=19.10b",
         "coloredlogs>=10.0",
         "dynaconf>=3.1.4",
-        "pluggy>=0.13,<1.0",
+        "pluggy>=1.0",
         "python-dateutil>=2.8.1",
         "stix2-patterns == 1.3.0",
         "stix2>=3.0",

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -22,8 +22,8 @@ else:
 class ThreatBus(stoppable_worker.StoppableWorker):
     def __init__(
         self,
-        backbones: pluggy.hooks._HookRelay,
-        apps: pluggy.hooks._HookRelay,
+        backbones: pluggy._hooks._HookRelay,
+        apps: pluggy._hooks._HookRelay,
         logger: Logger,
         config: Settings,
     ):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The release of pluggy 1.0 broke threatbus, since we use
type annotations for our arguments and the module containing
the _HookRelay class was renamed from `pluggy.hooks`
to `pluggy._hooks`.



<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
