### PR TITLE
Prepare repository for Threat Bus 2021.09.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental Features
 - 🐞 Bug Fixes
 
-## Unreleased
+## [2021.09.30]
 
 - ⚠️  `threatbus` now depends on version 1.0 of `pluggy`.
 
@@ -258,3 +258,4 @@ Every entry has a category for which we use the following visual abbreviations:
 [2021.06.24]: https://github.com/tenzir/threatbus/releases/tag/2021.06.24
 [2021.07.29]: https://github.com/tenzir/threatbus/releases/tag/2021.07.29
 [2021.08.26]: https://github.com/tenzir/threatbus/releases/tag/2021.08.26
+[2021.09.30]: https://github.com/tenzir/threatbus/releases/tag/2021.09.30

--- a/apps/stix-shifter/CHANGELOG.md
+++ b/apps/stix-shifter/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
+## [2021.09.30]
+
+No user-facing changes.
+
 ## [2021.08.26]
 
 - ⚠️ `stix-shifter-threatbus` now depends on version 3.0 of `stix2` package.
@@ -75,3 +79,4 @@ Every entry has a category for which we use the following visual abbreviations:
 [2021.06.24]: https://github.com/tenzir/threatbus/releases/tag/2021.06.24
 [2021.07.29]: https://github.com/tenzir/threatbus/releases/tag/2021.07.29
 [2021.08.26]: https://github.com/tenzir/threatbus/releases/tag/2021.08.26
+[2021.09.30]: https://github.com/tenzir/threatbus/releases/tag/2021.09.30

--- a/apps/stix-shifter/setup.py
+++ b/apps/stix-shifter/setup.py
@@ -36,7 +36,7 @@ setup(
         "stix2 >= 3.0",
         "stix-shifter >= 3.4.2",
         "stix-shifter-utils >= 3.4.2",
-        "threatbus >= 2021.8.26",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "open source",
@@ -54,5 +54,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/apps/suricata/CHANGELOG.md
+++ b/apps/suricata/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
+## [2021.09.30]
+
+No user-facing changes.
+
 ## [2021.08.26]
 
 - ⚠️ `suricata-threatbus` now depends on version 3.0 of `stix2` package.
@@ -58,3 +62,4 @@ Every entry has a category for which we use the following visual abbreviations:
 [2021.06.24]: https://github.com/tenzir/threatbus/releases/tag/2021.06.24
 [2021.07.29]: https://github.com/tenzir/threatbus/releases/tag/2021.07.29
 [2021.08.26]: https://github.com/tenzir/threatbus/releases/tag/2021.08.26
+[2021.09.30]: https://github.com/tenzir/threatbus/releases/tag/2021.09.30

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -32,7 +32,7 @@ setup(
         "pyzmq >= 19",
         "parsuricata",
         "stix2 >= 3.0",
-        "threatbus >= 2021.8.26",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "open source",
@@ -53,5 +53,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Changes
 - 🐞 Bug Fixes
 
+## [2021.09.30]
+
+No user-facing changes.
+
 ## [2021.08.26]
 
 - ⚡️ We renamed PyVAST Threat Bus to VAST Threat Bus for clarity. The PyPI
@@ -209,3 +213,4 @@ Every entry has a category for which we use the following visual abbreviations:
 [2021.06.24]: https://github.com/tenzir/threatbus/releases/tag/2021.06.24
 [2021.07.29]: https://github.com/tenzir/threatbus/releases/tag/2021.07.29
 [2021.08.26]: https://github.com/tenzir/threatbus/releases/tag/2021.08.26
+[2021.09.30]: https://github.com/tenzir/threatbus/releases/tag/2021.09.30

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -33,7 +33,7 @@ setup(
         "pyzmq >= 19",
         "pyvast >= 2021.6.24",
         "stix2 >= 3.0",
-        "threatbus >= 2021.8.26",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "open source",
@@ -52,5 +52,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/apps/zmq-app-template/setup.py
+++ b/apps/zmq-app-template/setup.py
@@ -31,7 +31,7 @@ setup(
         "dynaconf >= 3.1.4",
         "pyzmq >= 19",
         "stix2 >= 3.0",
-        "threatbus >= 2021.8.26",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "open source",
@@ -49,5 +49,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/docker/vast-threatbus/Dockerfile
+++ b/docker/vast-threatbus/Dockerfile
@@ -1,7 +1,7 @@
 # The used version here always refers to the latest released VAST version.
 # Use `latest` to get the most recent version of VAST as it is available on the
 # Git master branch at https://github.com/tenzir/vast.
-ARG VAST_VERSION=2021.08.26
+ARG VAST_VERSION=2021.09.30
 
 FROM tenzir/vast:$VAST_VERSION
 USER root

--- a/plugins/apps/threatbus_cif3/setup.py
+++ b/plugins/apps/threatbus_cif3/setup.py
@@ -27,7 +27,7 @@ setup(
     entry_points={"threatbus.app": ["cif3 = threatbus_cif3.plugin"]},
     install_requires=[
         "stix2 >= 3.0",
-        "threatbus >= 2021.5.27",
+        "threatbus >= 2021.9.30",
         "cifsdk > 3.0.0rc4, < 4.0",
     ],
     keywords=[
@@ -49,5 +49,5 @@ setup(
     packages=["threatbus_cif3"],
     python_requires=">=3.6",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/apps/threatbus_misp/setup.py
+++ b/plugins/apps/threatbus_misp/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "pymisp >= 2.4.120",
         "stix2 >= 3.0",
-        "threatbus >= 2021.5.27",
+        "threatbus >= 2021.9.30",
     ],
     extras_require={"kafka": ["confluent-kafka>=1.3.0"], "zmq": ["pyzmq>=18.1.1"]},
     keywords=[
@@ -49,5 +49,5 @@ setup(
     packages=["threatbus_misp"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/apps/threatbus_zeek/setup.py
+++ b/plugins/apps/threatbus_zeek/setup.py
@@ -27,7 +27,7 @@ setup(
     entry_points={"threatbus.app": ["zeek = threatbus_zeek.plugin"]},
     install_requires=[
         "stix2 >= 3.0",
-        "threatbus >= 2021.5.27",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "Zeek",
@@ -50,5 +50,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/apps/threatbus_zmq/setup.py
+++ b/plugins/apps/threatbus_zmq/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyzmq>=19",
         "python-dateutil>=2.8.1",
         "stix2>=3.0",
-        "threatbus>=2021.5.27",
+        "threatbus>=2021.9.30",
     ],
     keywords=[
         "zeromq",
@@ -47,5 +47,5 @@ setup(
     packages=["threatbus_zmq"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/backbones/file_benchmark/setup.py
+++ b/plugins/backbones/file_benchmark/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={"threatbus.backbone": ["file_benchmark = file_benchmark.plugin"]},
     install_requires=[
         "stix2 >= 3.0",
-        "threatbus >= 2021.2.24",
+        "threatbus >= 2021.9.30",
     ],
     keywords=["threatbus", "plugin"],
     license="BSD 3-clause",
@@ -34,5 +34,5 @@ setup(
     packages=["file_benchmark"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/backbones/threatbus_inmem/setup.py
+++ b/plugins/backbones/threatbus_inmem/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={"threatbus.backbone": ["inmem = threatbus_inmem.plugin"]},
     install_requires=[
         "stix2 >= 3.0",
-        "threatbus >= 2021.5.27",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "message broker",
@@ -41,5 +41,5 @@ setup(
     packages=["threatbus_inmem"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/plugins/backbones/threatbus_rabbitmq/setup.py
+++ b/plugins/backbones/threatbus_rabbitmq/setup.py
@@ -26,7 +26,7 @@ setup(
         "pika >= 1.1.0",
         "retry",
         "stix2 >= 3.0",
-        "threatbus >= 2021.5.27",
+        "threatbus >= 2021.9.30",
     ],
     keywords=[
         "message broker",
@@ -46,5 +46,5 @@ setup(
     packages=["threatbus_rabbitmq"],
     python_requires=">=3.7",
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/threatbus",
-    version="2021.08.26",
+    version="2021.09.30",
 )


### PR DESCRIPTION
This is mostly a maintenance release; just dependency changes and updating the Dockerfile to today's VAST release to keep everything synchronized.