### PR TITLE
Use low-priority exports if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🧬 Experimental Features
 - 🐞 Bug Fixes
 
+## [unreleased]
+
+- ⚠️ `vast-threatbus` now issues low priority queries if those are supported by
+  the version of VAST.
+  [#171](https://github.com/tenzir/threatbus/pull/171)
+
 ## [2021.09.30]
 
 - ⚠️  `threatbus` now depends on version 1.0 of `pluggy`.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

`vast-threatbus` now uses the `low-priority` option if supported by the vast instance.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
