### PR TITLE
Make Threat Bus independent of pluggy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black>=19.10b
 coloredlogs>=10.0
 dynaconf>=3.1.4
-pluggy>=1.0
+pluggy>=0.13
 python-dateutil>=2.8.1
 stix2-patterns == 1.3.0
 stix2>=3.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "black>=19.10b",
         "coloredlogs>=10.0",
         "dynaconf>=3.1.4",
-        "pluggy>=1.0",
+        "pluggy>=0.13",
         "python-dateutil>=2.8.1",
         "stix2-patterns == 1.3.0",
         "stix2>=3.0",

--- a/threatbus/threatbus.py
+++ b/threatbus/threatbus.py
@@ -18,12 +18,17 @@ if sys.version_info >= (3, 8):
 else:
     import importlib_metadata
 
+if pluggy.__version__.startswith("0"):
+    hook_relay_type = pluggy.hooks._HookRelay
+else:
+    hook_relay_type = pluggy._hooks._HookRelay
+
 
 class ThreatBus(stoppable_worker.StoppableWorker):
     def __init__(
         self,
-        backbones: pluggy._hooks._HookRelay,
-        apps: pluggy._hooks._HookRelay,
+        backbones: hook_relay_type,
+        apps: hook_relay_type,
         logger: Logger,
         config: Settings,
     ):


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR removes the requirement for a specific pre- or post-1.0 version of the `pluggy` dependency to allow interoperability with older versions.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries. (n/a)
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary. (n/a)
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I have tested this successfully in a virtualenv with 0.13.1 and 1.0.0. If you can imagine other cases worthy of testing, feel free to go on.