### PR TITLE
Correctly compare orgids between filter and MISP

### DIFF
--- a/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
@@ -193,9 +193,13 @@ def is_whitelisted(misp_msg: dict, filter_config: List[Dict]):
         return True
     for fil in filter_config:
         if (
-            # we check int(org_id) as well because MISP can give us strings for
-            # numeric org IDs
-            (not fil.get("orgs", None) or org_id in fil["orgs"] or int(org_id) in fil["orgs"])
+            (
+                # we check int(org_id) as well because MISP can give us strings
+                # for numeric org IDs
+                not fil.get("orgs", None)
+                or org_id in fil["orgs"]
+                or int(org_id) in fil["orgs"]
+            )
             and (not fil.get("types", None) or intel_type in fil["types"])
             and (
                 not fil.get("tags", None)

--- a/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
@@ -193,7 +193,9 @@ def is_whitelisted(misp_msg: dict, filter_config: List[Dict]):
         return True
     for fil in filter_config:
         if (
-            (not fil.get("orgs", None) or org_id in fil["orgs"])
+            # we check int(org_id) as well because MISP can give us strings for
+            # numeric org IDs
+            (not fil.get("orgs", None) or org_id in fil["orgs"] or int(org_id) in fil["orgs"])
             and (not fil.get("types", None) or intel_type in fil["types"])
             and (
                 not fil.get("tags", None)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR fixes an issue in the MISP plugin where filters with orgids would cause MISP indicators not to be filtered correctly. This is because orgids in the filter are parsed to integers internally by the config engine, but the MISP JSON presents the corresponding value as a string, causing a check to never succeed. This is addressed by interpreting the string value from MISP as an integer (which is expected)  and comparing that. We keep the original string comparison to allow string values in the filter config to still match, for whatever reason they might appear.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

No special instructions.