### PR TITLE
Add a new '%matchtype' variable to transform_context in vast-threatbus 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 Added a new field `%matchtype` to the `transform_context` setting of
+  `vast-threatbus` that can be used to distinguish between live and retro
+  matches.
+
 - ⚠️ `vast-threatbus` no longer adds a `source` field to the `x_threatbus_sighting_context`
   field of generated sightings.
 

--- a/apps/vast/CHANGELOG.md
+++ b/apps/vast/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 Added a new field `%matchtype` to the `transform_context` setting of
+  `vast-threatbus` that can be used to distinguish between live and retro
+  matches.
+
 - ⚠️ `vast-threatbus` no longer adds a `source` field to the `x_threatbus_sighting_context`
   field of generated sightings.
 

--- a/apps/vast/vast_threatbus/message_mapping.py
+++ b/apps/vast/vast_threatbus/message_mapping.py
@@ -1,7 +1,7 @@
 from dateutil import parser as dateutil_parser
 import json
 from stix2 import Indicator, Sighting
-from threatbus.data import ThreatBusSTIX2Constants
+from threatbus.data import ThreatBusSTIX2Constants, MatchType
 from threatbus.stix2_helpers import is_point_equality_ioc, split_object_path_and_value
 from typing import Tuple, Union
 import logging
@@ -111,6 +111,7 @@ def query_result_to_sighting(
             custom_properties={
                 ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,
                 ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR.value: indicator,
+                ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE.value: MatchType.RETRO,
             },
         )
     except Exception as e:
@@ -160,5 +161,6 @@ def matcher_result_to_sighting(matcher_result: str) -> Union[Sighting, None]:
         custom_properties={
             ThreatBusSTIX2Constants.X_THREATBUS_SIGHTING_CONTEXT.value: context,
             ThreatBusSTIX2Constants.X_THREATBUS_INDICATOR_VALUE.value: ioc_value,
+            ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE.value: MatchType.LIVE,
         },
     )

--- a/apps/vast/vast_threatbus/vast_threatbus.py
+++ b/apps/vast/vast_threatbus/vast_threatbus.py
@@ -688,7 +688,7 @@ async def transform_context(sighting: Sighting, transform_cmd: str) -> Sighting:
         return
     matchtype = (
         sighting.x_threatbus_match_type
-        if ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE in sighting
+        if ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE.value in sighting
         else None
     )
     transformed_context_raw = await invoke_cmd_for_context(

--- a/apps/vast/vast_threatbus/vast_threatbus.py
+++ b/apps/vast/vast_threatbus/vast_threatbus.py
@@ -545,7 +545,9 @@ async def live_match_vast(
     logger.critical("Unexpected exit of VAST matcher process.")
 
 
-async def invoke_cmd_for_context(cmd: str, context: dict, ioc: str = "%ioc"):
+async def invoke_cmd_for_context(
+    cmd: str, context: dict, ioc: str = "%ioc", matchtype: str = "%matchtype"
+):
     """
     Invoke a command as subprocess for the given context. The command string is
     treated as template string and occurences of "%ioc" are replaced with the
@@ -556,10 +558,14 @@ async def invoke_cmd_for_context(cmd: str, context: dict, ioc: str = "%ioc"):
         the actually matched IoC.
     @param context The context to forward as JSON
     @param ioc The value to replace '%ioc' with in the `cmd` string
+    @param matchtype The value to replace '%matchtype' with in the `cmd` string
     """
     if not ioc:
         ioc = "%ioc"
+    if not matchtype:
+        matchtype = "%matchtype"
     cmd = cmd.replace("%ioc", ioc)
+    cmd = cmd.replace("%matchtype", matchtype)
     proc = await asyncio.create_subprocess_exec(
         *lexical_split(cmd),
         stdout=asyncio.subprocess.PIPE,
@@ -620,6 +626,11 @@ async def report_sightings(
                 in sighting
                 else None
             )
+            matchtype = (
+                sighting.x_threatbus_match_type
+                if ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE.value in sighting
+                else None
+            )
             if not context:
                 logger.warn(
                     f"Cannot report sighting context to custom sink because no context data is found in the sighting {sighting}"
@@ -628,7 +639,7 @@ async def report_sightings(
             if sink.lower() == "stdout":
                 print(json.dumps(context))
             else:
-                await invoke_cmd_for_context(sink, context)
+                await invoke_cmd_for_context(sink, context, matchtype=matchtype)
         else:
             socket.send_string(f"{topic} {sighting.serialize()}")
         sightings_queue.task_done()
@@ -675,8 +686,13 @@ async def transform_context(sighting: Sighting, transform_cmd: str) -> Sighting:
             f"Cannot invoke `transform_context` command because no indicator value is found in the sighting {sighting}"
         )
         return
+    matchtype = (
+        sighting.x_threatbus_match_type
+        if ThreatBusSTIX2Constants.X_THREATBUS_MATCH_TYPE in sighting
+        else None
+    )
     transformed_context_raw = await invoke_cmd_for_context(
-        transform_cmd, context, ioc_value
+        transform_cmd, context, ioc=ioc_value, matchtype=matchtype
     )
     try:
         transformed_context = json.loads(transformed_context_raw)

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -9,12 +9,14 @@ from typing import List, Union
 ## Threat Bus custom STIX-2 attributes
 @unique
 class ThreatBusSTIX2Constants(Enum):
-    # used in Sighting.custom_properties to reference the full STIX-2 Indicator
+    # Used in Sighting.custom_properties to reference the full STIX-2 Indicator
     X_THREATBUS_INDICATOR = "x_threatbus_indicator"
-    # used in Sighting.custom_properties to reference the Indicator value, in
+    # Used in Sighting.custom_properties to reference the Indicator value, in
     # case the full indicator is not present any more.
     X_THREATBUS_INDICATOR_VALUE = "x_threatbus_indicator_value"
-    # used in Sighting.custom_properties.context
+    # Use to Sighting.custom_properties to indicate live or retro match
+    X_THREATBUS_MATCHTYPE = "x_threatbus_matchtype"
+    # Used in Sighting.custom_properties.context
     X_THREATBUS_SOURCE = "x_threatbus_source"
     X_THREATBUS_SIGHTING_CONTEXT = "x_threatbus_sighting_context"
     # Indicates an update operation for the STIX-2 item. See Operation enum.
@@ -40,6 +42,12 @@ class Unsubscription:
 class Operation(Enum):
     EDIT = "EDIT"
     REMOVE = "REMOVE"
+
+
+@unique
+class MatchType(Enum):
+    LIVE = "LIVE"
+    RETRO = "RETRO"
 
 
 @unique

--- a/threatbus/data.py
+++ b/threatbus/data.py
@@ -15,7 +15,7 @@ class ThreatBusSTIX2Constants(Enum):
     # case the full indicator is not present any more.
     X_THREATBUS_INDICATOR_VALUE = "x_threatbus_indicator_value"
     # Use to Sighting.custom_properties to indicate live or retro match
-    X_THREATBUS_MATCHTYPE = "x_threatbus_matchtype"
+    X_THREATBUS_MATCH_TYPE = "x_threatbus_match_type"
     # Used in Sighting.custom_properties.context
     X_THREATBUS_SOURCE = "x_threatbus_source"
     X_THREATBUS_SIGHTING_CONTEXT = "x_threatbus_sighting_context"
@@ -45,15 +45,16 @@ class Operation(Enum):
 
 
 @unique
-class MatchType(Enum):
-    LIVE = "LIVE"
-    RETRO = "RETRO"
-
-
-@unique
 class MessageType(Enum):
     INDICATOR = auto()
     SIGHTING = auto()
+
+
+# Let this enum inherit from string to enable JSON serialization.
+@unique
+class MatchType(str, Enum):
+    LIVE = "LIVE"
+    RETRO = "RETRO"
 
 
 @dataclass()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
