### PR TITLE
Use orgc_id instead of org_id for MISP filtering

### DIFF
--- a/plugins/apps/threatbus_misp/README.md
+++ b/plugins/apps/threatbus_misp/README.md
@@ -76,7 +76,7 @@ plugins:
       ssl: false
       key: MISP_API_KEY
     filter: # filter are optional. you can omit the entire section.
-      - orgs: # org IDs must be strings: https://github.com/MISP/PyMISP/blob/main/pymisp/data/schema.json
+      - orgs: # creator org IDs must be strings: https://github.com/MISP/PyMISP/blob/main/pymisp/data/schema.json
           - "1"
           - "25"
         tags:
@@ -112,8 +112,8 @@ The plugin can be configured with a list of filters. Every filter describes a
 whitelist for MISP attributes (IoCs). The MISP plugin will only forward IoCs to
 Threat Bus if the whitelisted properties are present.
 
-A filter consists of three sub-whitelists for organizations, types, and tags.
-To pass through the filter, an attribute must provide at least one of the
+A filter consists of three sub-whitelists for creator organizations, types, and
+tags. To pass through the filter, an attribute must provide at least one of the
 whitelisted properties of each of the whitelists. More precisely, entries of
 each whitelist are linked by an `"or"`-function, the whitelists themselves are
 linked by an `"and"`-function, as follows:

--- a/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/message_mapping.py
@@ -183,10 +183,10 @@ def is_whitelisted(misp_msg: dict, filter_config: List[Dict]):
     attr = misp_msg.get("Attribute", None)
     if not event or not attr:
         return False
-    org_id = event.get("org_id", None)
+    orgc_id = event.get("orgc_id", None)
     intel_type = attr.get("type", None)
     tags = get_tags(attr)
-    if not org_id or not intel_type:
+    if not orgc_id or not intel_type:
         return False
     if not filter_config:
         # no whitelist = allow all
@@ -197,8 +197,8 @@ def is_whitelisted(misp_msg: dict, filter_config: List[Dict]):
                 # we check int(org_id) as well because MISP can give us strings
                 # for numeric org IDs
                 not fil.get("orgs", None)
-                or org_id in fil["orgs"]
-                or int(org_id) in fil["orgs"]
+                or orgc_id in fil["orgs"]
+                or int(orgc_id) in fil["orgs"]
             )
             and (not fil.get("types", None) or intel_type in fil["types"])
             and (

--- a/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
+++ b/plugins/apps/threatbus_misp/threatbus_misp/test_message_mapping.py
@@ -97,7 +97,7 @@ class TestMessageMapping(unittest.TestCase):
             "published": false,
             "analysis": "0",
             "threat_level_id": "1",
-            "org_id": "1",
+            "org_id": "3",
             "orgc_id": "1",
             "distribution": "1",
             "sharing_group_id": "0",


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

From a user's point of view, it is more useful to filter MISP events to forward by `orgc_id` (creator org) instead of `org_id` (owner org).  This PR reflects this in the filtering engine and also clarifies this in the README.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

No special instructions. Review tests carefully.