### PR TITLE
Pin dynaconf dependency to avoid a bug in 3.1.8

### DIFF
--- a/apps/stix-shifter/setup.py
+++ b/apps/stix-shifter/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "black >= 19.10b",
-        "dynaconf >= 3.1.4",
+        "dynaconf>=3.1.4,!=3.1.8",
         "python-dateutil",
         "pyzmq >= 19",
         "stix2 >= 3.0",

--- a/apps/suricata/setup.py
+++ b/apps/suricata/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "black >= 19.10b",
-        "dynaconf >= 3.1.4",
+        "dynaconf>=3.1.4,!=3.1.8",
         "pyzmq >= 19",
         "parsuricata",
         "stix2 >= 3.0",

--- a/apps/vast/setup.py
+++ b/apps/vast/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "black >= 19.10b",
-        "dynaconf >= 3.1.4",
+        "dynaconf>=3.1.4,!=3.1.8",
         "python-dateutil",
         "pyzmq >= 19",
         "pyvast >= 1.0.0",

--- a/apps/zmq-app-template/setup.py
+++ b/apps/zmq-app-template/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "black >= 19.10b",
-        "dynaconf >= 3.1.4",
+        "dynaconf>=3.1.4,!=3.1.8",
         "pyzmq >= 19",
         "stix2 >= 3.0",
         "threatbus >= 2022.1.27",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black>=19.10b
 coloredlogs>=10.0
-dynaconf>=3.1.4
+dynaconf>=3.1.4,!=3.1.8
 pluggy>=0.13
 python-dateutil>=2.8.1
 stix2-patterns == 1.3.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         "black>=19.10b",
         "coloredlogs>=10.0",
-        "dynaconf>=3.1.4",
+        "dynaconf>=3.1.4,!=3.1.8",
         "pluggy>=0.13",
         "python-dateutil>=2.8.1",
         "stix2-patterns == 1.3.0",


### PR DESCRIPTION
See https://github.com/rochacbruno/dynaconf/issues/741 for the details.
Validators for logging configuration don't work for 3.1.8.

###  :notebook_with_decorative_cover: Description

This modifies all places where we define the dynaconf dependency to avoid version 3.1.8.

###  :memo: Checklist

- [x ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/threatbus](https://docs.tenzir.com/threatbus), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Make sure I'm not missing a place.